### PR TITLE
fix: hit test on episodes grid vs shows grid

### DIFF
--- a/src/Ch9/Ch9.Shared/MainPage.xaml
+++ b/src/Ch9/Ch9.Shared/MainPage.xaml
@@ -203,6 +203,7 @@
 		<!-- Episodes list -->
 		<Grid DataContext="{Binding Show}"
               Opacity="{Binding IsChecked, ElementName=FreshContentBtn, Converter={StaticResource TrueToOpaque}}"
+              IsHitTestVisible="{Binding IsChecked, ElementName=FreshContentBtn}"
               Grid.Row="2"
               Grid.Column="0">
 

--- a/src/Ch9/Ch9.Shared/Styles/Controls/GridView.xaml
+++ b/src/Ch9/Ch9.Shared/Styles/Controls/GridView.xaml
@@ -45,7 +45,6 @@
 								<VisualState x:Name="Normal" />
                                 <VisualState x:Name="PointerOver" />
                                 <VisualState x:Name="Pressed" />
-
                             </VisualStateGroup>
 						</VisualStateManager.VisualStateGroups>
 
@@ -69,7 +68,7 @@
 		<Setter Property="ItemContainerStyle">
 			<Setter.Value>
 				<Style TargetType="GridViewItem"
-					   xamarin:BasedOn="{StaticResource LeanGridViewItemExpanded}">
+					   BasedOn="{StaticResource LeanGridViewItemExpanded}">
 					<Setter Property="VerticalContentAlignment"
 							Value="Stretch" />
 					<Setter Property="HorizontalContentAlignment"


### PR DESCRIPTION
Fixes hit test on the shows GridView that was intercepted by the episodes Grid. Also uses the GridViewItem style on UWP.