### PR TITLE
Navigation / Fullscreen fixes

### DIFF
--- a/src/Ch9/Ch9.Droid/Ch9.Droid.csproj
+++ b/src/Ch9/Ch9.Droid/Ch9.Droid.csproj
@@ -67,7 +67,6 @@
     <PackageReference Include="Uno.UI" Version="2.3.0-dev.90" />
     <PackageReference Include="Uno.UI.Lottie" Version="2.3.0-dev.90" />
     <PackageReference Include="Com.Airbnb.Android.Lottie" Version="2.5.2.1" />
-    <PackageReference Include="Uno.UI.RemoteControl" Version="2.3.0-dev.90" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Uno.UniversalImageLoader" Version="1.9.32" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />

--- a/src/Ch9/Ch9.Shared/EpisodeContent.xaml
+++ b/src/Ch9/Ch9.Shared/EpisodeContent.xaml
@@ -80,16 +80,11 @@
 
         <!-- Content -->
         <StackPanel>
-
-            <Grid toolkit:VisibleBoundsPadding.PaddingMask="Top">
-
-                <!-- Video Player -->
-                <MediaPlayerElement x:Name="MediaPlayer"
-									Source="{Binding VideoSource}"
-									IsFullWindow="{Binding Parent.IsVideoFullWindow, Mode=TwoWay}"
-									Height="180" />
-            </Grid>
-
+            <!-- Video Player -->
+            <MediaPlayerElement x:Name="MediaPlayer"
+                                Source="{Binding VideoSource}"
+                                IsFullWindow="{Binding Parent.IsVideoFullWindow, Mode=TwoWay}"
+                                Height="180" />
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*"

--- a/src/Ch9/Ch9.Shared/MainPage.xaml
+++ b/src/Ch9/Ch9.Shared/MainPage.xaml
@@ -58,8 +58,14 @@
 						<Setter Target="EpisodePresenter.Column"
 								Value="1" />
 						<Setter Target="EpisodePresenter.ColumnSpan"
-								Value="1" />
-						<Setter Target="ModalBackground.Visibility"
+                                Value="1" />
+                        <Setter Target="EpisodePresenter.Row"
+                                Value="2" />
+                        <Setter Target="EpisodePresenter.RowSpan"
+                                Value="1" />
+                        <Setter Target="EpisodePresenter.IsHitTestVisible"
+                                Value="True" />
+                        <Setter Target="ModalBackground.Visibility"
 								Value="Collapsed" />
 						<Setter Target="DismissButton.Visibility"
 								Value="Collapsed" />
@@ -87,7 +93,11 @@
 								Value="1" />
 						<Setter Target="EpisodePresenter.ColumnSpan"
 								Value="1" />
-						<Setter Target="ModalBackground.Visibility"
+                        <Setter Target="EpisodePresenter.Row"
+                                Value="2" />
+                        <Setter Target="EpisodePresenter.RowSpan"
+                                Value="1" />
+                        <Setter Target="ModalBackground.Visibility"
 								Value="Collapsed" />
 						<Setter Target="DismissButton.Visibility"
 								Value="Collapsed" />
@@ -104,13 +114,11 @@
 					</VisualState.StateTriggers>
 
 					<VisualState.Setters>
-						<Setter Target="CommandBar.Visibility"
-								Value="Collapsed" />
-						<Setter Target="EpisodePresenter.Row"
-								Value="0" />
-						<Setter Target="EpisodePresenter.RowSpan"
-								Value="3" />
-					</VisualState.Setters>
+                        <Setter Target="CommandBar.Visibility"
+                                Value="Collapsed" />
+                        <Setter Target="EpisodePresenter.IsHitTestVisible"
+                                Value="True" />                        
+                    </VisualState.Setters>
 				</VisualState>
 			</VisualStateGroup>
 		</VisualStateManager.VisualStateGroups>
@@ -287,42 +295,41 @@
 		<!-- Selected Episode -->
 		<Grid x:Name="EpisodePresenter"
 			  DataContext="{Binding Show}"
-			  Visibility="{Binding IsChecked, ElementName=FreshContentBtn, Converter={StaticResource TrueToVisible}}"
-			  Grid.Row="2"
+              Visibility="{Binding IsChecked, ElementName=FreshContentBtn, Converter={StaticResource TrueToVisible}}"
+              IsHitTestVisible="False"
+			  Grid.Row="0"
+              Grid.RowSpan="3"
 			  Grid.Column="0"
 			  Grid.ColumnSpan="2">
 
-			<Grid Visibility="{Binding SelectedEpisode, Converter={StaticResource NullToCollapsed}, FallbackValue=Collapsed}"
+            <Grid Visibility="{Binding SelectedEpisode, Converter={StaticResource NullToCollapsed}, FallbackValue=Collapsed}"
                   toolkit:VisibleBoundsPadding.PaddingMask="Top"
                   Background="{StaticResource Color02Brush}">
 
 				<!-- Modal background -->
 				<Border x:Name="ModalBackground"
-						Background="{StaticResource Color02Brush}" />
+                        Background="{StaticResource Color02Brush}" />
 
 				<!-- Presenter -->
 				<ScrollViewer>
 
 					<!-- Episode -->
 					<local:EpisodeContent DataContext="{Binding SelectedEpisode}"
-										  VerticalAlignment="Top" />
+										  VerticalAlignment="Top" />                    
 				</ScrollViewer>
 
-				<Grid>
-
-					<!-- Dismiss button -->
-					<Button x:Name="DismissButton"
-							Command="{Binding DismissSelectedEpisode}"
-							Style="{StaticResource VideoPlayerButtonStyle}"
-							HorizontalAlignment="Right"
-							VerticalAlignment="Top"
-							Margin="8">
-						<Path Style="{StaticResource CloseIconPath}"
-							  Data="M21.976 2.438L23.563 4.024 14.586 13 23.563 21.976 21.976 23.563 13 14.586 4.024 23.563 2.438 21.976 11.413 13 2.438 4.024 4.024 2.438 13 11.413z"
-							  VerticalAlignment="Center" />
-					</Button>
-				</Grid>
-			</Grid>
+				<!-- Dismiss button -->
+                <Button x:Name="DismissButton"
+                        Command="{Binding DismissSelectedEpisode}"
+                        Style="{StaticResource VideoPlayerButtonStyle}"
+                        HorizontalAlignment="Right"
+                        VerticalAlignment="Top"
+                        Margin="8">
+                    <Path Style="{StaticResource CloseIconPath}"
+                          Data="M21.976 2.438L23.563 4.024 14.586 13 23.563 21.976 21.976 23.563 13 14.586 4.024 23.563 2.438 21.976 11.413 13 2.438 4.024 4.024 2.438 13 11.413z"
+                          VerticalAlignment="Center" />
+                </Button>
+            </Grid>
 		</Grid>
 
 		<!-- Error -->

--- a/src/Ch9/Ch9.Shared/MainPage.xaml
+++ b/src/Ch9/Ch9.Shared/MainPage.xaml
@@ -11,8 +11,7 @@
 	  xmlns:winui="using:Microsoft.UI.Xaml.Controls"
 	  xmlns:android="http://Uno.UI/android"
 	  xmlns:triggers="using:WindowsStateTriggers"
-	  mc:Ignorable="d android"
-	  x:Name="This">
+	  mc:Ignorable="d android">
 
 	<Grid Background="{ThemeResource AppBackgroundBrush}">
 
@@ -168,8 +167,8 @@
 			<GridView.ItemTemplate>
 				<DataTemplate>
 
-					<Button Command="{Binding ElementName=This, Path=DataContext.DisplayShow}"
-							CommandParameter="{Binding}"
+					<Button Command="{Binding Parent.DisplayShow}"
+							CommandParameter="{Binding Show}"
 							Style="{StaticResource HiddenButtonStyle}">
 
 						<toolkit:ElevatedView Background="{StaticResource Color02Brush}"
@@ -184,14 +183,14 @@
 									<!-- Image -->
 									<Border Background="{StaticResource Color07Brush}"
 											CornerRadius="8,8,0,0">
-										<Image Source="{Binding Image}"
+										<Image Source="{Binding Show.Image}"
 											   Stretch="UniformToFill"
 											   Height="200"
 											   Width="355" />
 									</Border>
 
 									<!-- Label -->
-									<TextBlock Text="{Binding Name}"
+                                    <TextBlock Text="{Binding Show.Name}"
 											   Style="{StaticResource Typo02}"
 											   Margin="12,8,0,16" />
 								</StackPanel>

--- a/src/Ch9/Ch9.Shared/ShowPage.xaml
+++ b/src/Ch9/Ch9.Shared/ShowPage.xaml
@@ -249,6 +249,7 @@
         <Grid x:Name="EpisodePresenter"
               DataContext="{Binding Show}"
               Visibility="{Binding SelectedEpisode, Converter={StaticResource NullToCollapsed}, FallbackValue=Collapsed}"
+              toolkit:VisibleBoundsPadding.PaddingMask="Top"
               Background="{StaticResource Color02Brush}"
               Grid.Row="2"
               Grid.Column="0">
@@ -265,7 +266,7 @@
                                       VerticalAlignment="Top" />
             </ScrollViewer>
 
-            <Grid toolkit:VisibleBoundsPadding.PaddingMask="Top">
+            <Grid>
 
                 <!-- Dismiss button -->
                 <Button x:Name="DismissButton"

--- a/src/Ch9/Ch9.Shared/ViewModels/MainPageViewModel.cs
+++ b/src/Ch9/Ch9.Shared/ViewModels/MainPageViewModel.cs
@@ -21,6 +21,7 @@ namespace Ch9
             Shows = App.ServiceProvider.GetInstance<IShowService>()
                 .GetShowFeeds()
                 .OrderBy(s => s.Name)
+                .Select(s => new ShowItemViewModel(this, s))
                 .ToArray();
 
             DisplayShow = new RelayCommand<SourceFeed>(showFeed  =>
@@ -33,7 +34,7 @@ namespace Ch9
 
         public ICommand DisplayShow { get; set; }
 
-        public IEnumerable<SourceFeed> Shows { get; set; }
+        public IEnumerable<ShowItemViewModel> Shows { get; set; }
 
         private ShowViewModel _show;
         public ShowViewModel Show
@@ -48,6 +49,19 @@ namespace Ch9
             {
                 Show = new ShowViewModel();
             }
+        }
+    }
+
+    public class ShowItemViewModel
+    {
+        public ViewModelBase Parent { get; set; }
+
+        public SourceFeed Show { get; set; }
+
+        public ShowItemViewModel(ViewModelBase parent, SourceFeed show)
+        {
+            Parent = parent;
+            Show = show;
         }
     }
 }


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

- iOS: Can't navigate to a show after 3-4 back-and-forth
- Android: Going into full screen mode shows a white margin at the top.

## What is the new behavior?

- iOS: Fixes binding issue by using item view models.
- Android: Removes double visible bounds padding
