### PR TITLE
[BugFix] Fixed alignment issue on full screen episode 

### DIFF
--- a/src/Ch9/Ch9.Shared/MainPage.xaml
+++ b/src/Ch9/Ch9.Shared/MainPage.xaml
@@ -325,7 +325,7 @@
 						Style="{StaticResource VideoPlayerButtonStyle}"
 						HorizontalAlignment="Right"
 						VerticalAlignment="Top"
-						Margin="8">
+						Margin="8,8,16,8">
 					<Path Style="{StaticResource CloseIconPath}"
 						  Data="M21.976 2.438L23.563 4.024 14.586 13 23.563 21.976 21.976 23.563 13 14.586 4.024 23.563 2.438 21.976 11.413 13 2.438 4.024 4.024 2.438 13 11.413z"
 						  VerticalAlignment="Center" />

--- a/src/Ch9/Ch9.Shared/ShowPage.xaml
+++ b/src/Ch9/Ch9.Shared/ShowPage.xaml
@@ -275,7 +275,7 @@
 						Style="{StaticResource VideoPlayerButtonStyle}"
 						HorizontalAlignment="Right"
 						VerticalAlignment="Top"
-						Margin="8">
+						Margin="8,8,16,8">
 					<Path Style="{StaticResource CloseIconPath}"
 						  Data="M21.976 2.438L23.563 4.024 14.586 13 23.563 21.976 21.976 23.563 13 14.586 4.024 23.563 2.438 21.976 11.413 13 2.438 4.024 4.024 2.438 13 11.413z"
 						  VerticalAlignment="Center" />

--- a/src/Ch9/Ch9.Shared/Styles/Controls/MediaPlayerElement.xaml
+++ b/src/Ch9/Ch9.Shared/Styles/Controls/MediaPlayerElement.xaml
@@ -460,6 +460,7 @@
 								<!-- Icon -->
 								<Path x:Name="FullWindowSymbol"
 									  Style="{StaticResource FullScreenIconPath}"
+									  VerticalAlignment="Center"
 									  Data="M5.4,4l9.6,9.6L13.6,15L4,5.4V15H2V4V2h2h11v2H5.4z M28,17v9.6L18.4,17L17,18.4l9.6,9.6H17v2h11h2v-2V17H28z"/>
 							</Button>
 						</Grid>

--- a/src/Ch9/Ch9.Shared/Styles/Controls/Path.xaml
+++ b/src/Ch9/Ch9.Shared/Styles/Controls/Path.xaml
@@ -201,9 +201,9 @@
 		<Setter Property="Fill"
 				Value="{StaticResource MediaPlayerControlColorBrush}" />
 		<Setter Property="Width"
-				Value="24" />
+				Value="21" />
 		<Setter Property="Height"
-				Value="24" />
+				Value="21" />
 		
 		<Setter Property="Data"
 				Value="M5.4,4l9.6,9.6L13.6,15L4,5.4V15H2V4V2h2h11v2H5.4z M28,17v9.6L18.4,17L17,18.4l9.6,9.6H17v2h11h2v-2V17H28z" />


### PR DESCRIPTION


GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?


- Bugfix


## What is the current behavior?

- FullScreen icon and close icon not horizontally aligned

## What is the new behavior?

- Both buttons are now aligned. 


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
