### PR TITLE
feat: auto full screen video on landscape mode

### DIFF
--- a/src/Ch9/Ch9.Shared/App.xaml.cs
+++ b/src/Ch9/Ch9.Shared/App.xaml.cs
@@ -8,6 +8,7 @@ using System.Runtime.InteropServices.WindowsRuntime;
 using Uno.UI;
 using Windows.ApplicationModel;
 using Windows.ApplicationModel.Activation;
+using Windows.Devices.Sensors;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
 using Windows.Graphics.Display;
@@ -25,259 +26,273 @@ using Xamarin.Essentials;
 using Microsoft.AppCenter;
 using Microsoft.AppCenter.Analytics;
 using Microsoft.AppCenter.Crashes;
+using Uno.Extensions;
+using Uno.Logging;
 
 namespace Ch9
 {
-	/// <summary>
-	/// Provides application-specific behavior to supplement the default Application class.
-	/// </summary>
-	sealed partial class App : Application
-	{
-		public static App Instance { get; private set; }
+    /// <summary>
+    /// Provides application-specific behavior to supplement the default Application class.
+    /// </summary>
+    sealed partial class App : Application
+    {
+        public static App Instance { get; private set; }
 
-		private readonly Startup _startup;
-		private Frame _rootFrame;
+        private readonly Startup _startup;
+        private Frame _rootFrame;
 
-		public static SimpleIoc ServiceProvider { get; } = SimpleIoc.Default;
+        public static SimpleIoc ServiceProvider { get; } = SimpleIoc.Default;
 
-		/// <summary>
-		/// Initializes the singleton application object.  This is the first line of authored code
-		/// executed, and as such is the logical equivalent of main() or WinMain().
-		/// </summary>
-		public App()
-		{
-			Instance = this;
+        /// <summary>
+        /// Initializes the singleton application object.  This is the first line of authored code
+        /// executed, and as such is the logical equivalent of main() or WinMain().
+        /// </summary>
+        public App()
+        {
+            Instance = this;
 
-			// Uncomment this if you want to set a default theme.
-			// this.RequestedTheme = ApplicationTheme.Dark;
+            // Uncomment this if you want to set a default theme.
+            // this.RequestedTheme = ApplicationTheme.Dark;
 
-			_startup = new Startup();
+            _startup = new Startup();
 
 #if !DEBUG && WINDOWS_UWP
 			AppCenter.Start("68d4e1c1-d72c-491e-9c16-5302d9521fb1", typeof(Analytics), typeof(Crashes));
 #endif
 
-			ConfigureFilters(global::Uno.Extensions.LogExtensionPoint.AmbientLoggerFactory);
+            ConfigureFilters(global::Uno.Extensions.LogExtensionPoint.AmbientLoggerFactory);
 
-			this.InitializeComponent();
-			this.Suspending += OnSuspending;
-		}
+            this.InitializeComponent();
+            this.Suspending += OnSuspending;
+        }
 
-		/// <summary>
-		/// Invoked when the application is launched normally by the end user.  Other entry points
-		/// will be used such as when the application is launched to open a specific file.
-		/// </summary>
-		/// <param name="e">Details about the launch request and process.</param>
-		protected override void OnLaunched(LaunchActivatedEventArgs e)
-		{
+        /// <summary>
+        /// Invoked when the application is launched normally by the end user.  Other entry points
+        /// will be used such as when the application is launched to open a specific file.
+        /// </summary>
+        /// <param name="e">Details about the launch request and process.</param>
+        protected override void OnLaunched(LaunchActivatedEventArgs e)
+        {
 #if DEBUG
-			if (System.Diagnostics.Debugger.IsAttached)
-			{
-				// this.DebugSettings.EnableFrameRateCounter = true;
-			}
+            if (System.Diagnostics.Debugger.IsAttached)
+            {
+                // this.DebugSettings.EnableFrameRateCounter = true;
+            }
 #endif
-			_rootFrame = Windows.UI.Xaml.Window.Current.Content as Frame;
+            _rootFrame = Windows.UI.Xaml.Window.Current.Content as Frame;
 
-			// Do not repeat app initialization when the Window already has content,
-			// just ensure that the window is active
-			if (_rootFrame == null)
-			{
+            // Do not repeat app initialization when the Window already has content,
+            // just ensure that the window is active
+            if (_rootFrame == null)
+            {
 #if !DEBUG && __IOS__
 				AppCenter.Start("c1c95ee1-7532-486b-a542-cab21f444edb", typeof(Analytics), typeof(Crashes));
 #endif
 
-				_startup.Initialize(ServiceProvider);
+                _startup.Initialize(ServiceProvider);
 
-				ConfigureViewSize();
-				ConfigureStatusBar();
+                ConfigureViewSize();
+                ConfigureStatusBar();
 
-				// Create a Frame to act as the navigation context and navigate to the first page
-				_rootFrame = new Frame();
+                // Create a Frame to act as the navigation context and navigate to the first page
+                _rootFrame = new Frame();
 
-				_rootFrame.NavigationFailed += OnNavigationFailed;
+                _rootFrame.NavigationFailed += OnNavigationFailed;
 
-				// Place the frame in the current Window
-				Windows.UI.Xaml.Window.Current.Content = _rootFrame;
-			}
+                // Place the frame in the current Window
+                Windows.UI.Xaml.Window.Current.Content = _rootFrame;
+            }
 
-			if (e.PrelaunchActivated == false)
-			{
-				if (_rootFrame.Content == null)
-				{
-					// When the navigation stack isn't restored navigate to the first page,
-					// configuring the new page by passing required information as a navigation
-					// parameter
-					ConfigureSystemBackVisibility();
-					ConfigureBackRequests();
-					ConfigureOrientation();
+            if (e.PrelaunchActivated == false)
+            {
+                if (_rootFrame.Content == null)
+                {
+                    // When the navigation stack isn't restored navigate to the first page,
+                    // configuring the new page by passing required information as a navigation
+                    // parameter
+                    ConfigureSystemBackVisibility();
+                    ConfigureBackRequests();
+                    ConfigureOrientation();
 
-					ServiceProvider.GetInstance<IStackNavigationService>().NavigateTo(nameof(MainPage));
-				}
+                    ServiceProvider.GetInstance<IStackNavigationService>().NavigateTo(nameof(MainPage));
+                }
 
-				// Ensure the current window is active
-				Windows.UI.Xaml.Window.Current.Activate();
-			}
-		}
+                // Ensure the current window is active
+                Windows.UI.Xaml.Window.Current.Activate();
+            }
+        }
 
-		/// <summary>
-		/// Invoked when Navigation to a certain page fails
-		/// </summary>
-		/// <param name="sender">The Frame which failed navigation</param>
-		/// <param name="e">Details about the navigation failure</param>
-		void OnNavigationFailed(object sender, NavigationFailedEventArgs e)
-		{
-			throw new Exception($"Failed to load {e.SourcePageType.FullName}: {e.Exception}");
-		}
+        /// <summary>
+        /// Invoked when Navigation to a certain page fails
+        /// </summary>
+        /// <param name="sender">The Frame which failed navigation</param>
+        /// <param name="e">Details about the navigation failure</param>
+        void OnNavigationFailed(object sender, NavigationFailedEventArgs e)
+        {
+            throw new Exception($"Failed to load {e.SourcePageType.FullName}: {e.Exception}");
+        }
 
-		/// <summary>
-		/// Invoked when application execution is being suspended.  Application state is saved
-		/// without knowing whether the application will be terminated or resumed with the contents
-		/// of memory still intact.
-		/// </summary>
-		/// <param name="sender">The source of the suspend request.</param>
-		/// <param name="e">Details about the suspend request.</param>
-		private void OnSuspending(object sender, SuspendingEventArgs e)
-		{
-			var deferral = e.SuspendingOperation.GetDeferral();
+        /// <summary>
+        /// Invoked when application execution is being suspended.  Application state is saved
+        /// without knowing whether the application will be terminated or resumed with the contents
+        /// of memory still intact.
+        /// </summary>
+        /// <param name="sender">The source of the suspend request.</param>
+        /// <param name="e">Details about the suspend request.</param>
+        private void OnSuspending(object sender, SuspendingEventArgs e)
+        {
+            var deferral = e.SuspendingOperation.GetDeferral();
 
-			deferral.Complete();
-		}
+            deferral.Complete();
+        }
 
-		private void ConfigureViewSize()
-		{
+        private void ConfigureViewSize()
+        {
 #if WINDOWS_UWP
 			ApplicationView.PreferredLaunchViewSize = new Size(1024, 768);
 			ApplicationView.PreferredLaunchWindowingMode = ApplicationViewWindowingMode.PreferredLaunchViewSize;
 			ApplicationView.GetForCurrentView().SetPreferredMinSize(new Size(320, 480));
 #endif
-		}
+        }
 
-		private void ConfigureStatusBar()
-		{
-			var resources = Windows.UI.Xaml.Application.Current.Resources;
+        private void ConfigureStatusBar()
+        {
+            var resources = Windows.UI.Xaml.Application.Current.Resources;
 
 #if WINDOWS_UWP
 			var hasStatusBar = false;
 #else
-			var hasStatusBar = true;
+            var hasStatusBar = true;
 
-			StatusBar.GetForCurrentView().ForegroundColor = this.RequestedTheme == ApplicationTheme.Dark
-				? Windows.UI.Colors.White
-				: Windows.UI.Colors.Black;
+            StatusBar.GetForCurrentView().ForegroundColor = this.RequestedTheme == ApplicationTheme.Dark
+                ? Windows.UI.Colors.White
+                : Windows.UI.Colors.Black;
 #endif
 
-			var statusBarHeight = hasStatusBar ? Windows.UI.ViewManagement.StatusBar.GetForCurrentView().OccludedRect.Height : 0;
+            var statusBarHeight = hasStatusBar ? Windows.UI.ViewManagement.StatusBar.GetForCurrentView().OccludedRect.Height : 0;
 
-			resources.Add("StatusBarDouble", (double)statusBarHeight);
-			resources.Add("StatusBarThickness", new Thickness(0, statusBarHeight, 0, 0));
-			resources.Add("StatusBarGridLength", new GridLength(statusBarHeight, GridUnitType.Pixel));
-		}
+            resources.Add("StatusBarDouble", (double)statusBarHeight);
+            resources.Add("StatusBarThickness", new Thickness(0, statusBarHeight, 0, 0));
+            resources.Add("StatusBarGridLength", new GridLength(statusBarHeight, GridUnitType.Pixel));
+        }
 
-		private void ConfigureOrientation()
-		{
-			if (DeviceInfo.Idiom == DeviceIdiom.Phone)
-			{
-				DisplayInformation.AutoRotationPreferences = DisplayOrientations.Portrait;
-			}
+        private void ConfigureOrientation()
+        {
+            if (DeviceInfo.Idiom == DeviceIdiom.Phone)
+            {
+                DisplayInformation.AutoRotationPreferences = DisplayOrientations.Portrait;
+            }
 
-			void OnOrientationChanged(DisplayInformation displayInformation, object args)
-			{
+            var simpleOrientationSensor = SimpleOrientationSensor.GetDefault();
 
-				if ((_rootFrame.Content as FrameworkElement)?.DataContext is ShowPageViewModel showPage)
-				{
-					ToVideoFullWindow(showPage.Show, displayInformation);
-				}
-				else if ((_rootFrame.Content as FrameworkElement)?.DataContext is MainPageViewModel mainPage)
-				{
-					ToVideoFullWindow(mainPage.Show, displayInformation);
-				}
+            if (simpleOrientationSensor != null)
+            {
+                simpleOrientationSensor.OrientationChanged += OrientationChanged;
+            }
 
-				
-			}
+            void OrientationChanged(SimpleOrientationSensor sender, SimpleOrientationSensorOrientationChangedEventArgs args)
+            {
+                try
+                {
+                    var isLandscape = args.Orientation.IsOneOf(
+                        SimpleOrientation.Rotated270DegreesCounterclockwise,
+                        SimpleOrientation.Rotated90DegreesCounterclockwise
+                    );
 
-			DisplayInformation.GetForCurrentView().OrientationChanged += OnOrientationChanged;
-		}
+                    if ((_rootFrame.Content as FrameworkElement)?.DataContext is ShowPageViewModel showPage &&
+                        showPage.Show.SelectedEpisode != null)
+                    {
+                        ToVideoFullWindow(showPage.Show, isLandscape);
+                    }
+                    else if ((_rootFrame.Content as FrameworkElement)?.DataContext is MainPageViewModel mainPage &&
+                             mainPage.Show.SelectedEpisode != null)
+                    {
+                        ToVideoFullWindow(mainPage.Show, isLandscape);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    this.Log().ErrorIfEnabled(() => $"Error in OrientationChanged subscription: {ex.ToString()}");
+                }
+            }
+        }
 
-		/// <summary>
-		/// Sets the video to fullWindow depending on screen orientation
-		/// </summary>
-		/// <param name="showVm">The show vm for which we will change its property IsVideoFullWindow</param>
-		/// <param name="displayInformation">The displayInformation for the current view</param>
-		private void ToVideoFullWindow(ShowViewModel showVm, DisplayInformation displayInformation)
-		{
-			if (displayInformation.CurrentOrientation == DisplayOrientations.Landscape || 
-			    displayInformation.CurrentOrientation == DisplayOrientations.LandscapeFlipped 
-			    && showVm != null)
-			{
-				showVm.IsVideoFullWindow = true;
-			}
-			else
-			{
-				showVm.IsVideoFullWindow = false;
-			}
-		}
+        /// <summary>
+        /// Sets the video to fullWindow depending on screen orientation
+        /// </summary>
+        /// <param name="showVm">The show vm for which we will change its property IsVideoFullWindow</param>
+        /// <param name="isLandscape">Determine if the device is oriented in landscape</param>
+        private void ToVideoFullWindow(ShowViewModel showVm, bool isLandscape)
+        {
+            if (showVm == null)
+                return;
 
-		/// <summary>
-		/// Sets the visibility of the system UI's back button based on the navigation service.
-		/// </summary>
-		private void ConfigureSystemBackVisibility()
-		{
-			var navigationService = ServiceProvider.GetInstance<IStackNavigationService>();
+            //Set display orientation to none, thus screen can handle LandscapeFlipped
+            DisplayInformation.AutoRotationPreferences = DisplayOrientations.None;
+            showVm.IsVideoFullWindow = isLandscape;
+        }
 
-			void OnNavigated(IStackNavigationService sender, OnNavigatedEventArgs args)
-			{
-				SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility = sender.CanGoBack
-					? AppViewBackButtonVisibility.Visible
-					: AppViewBackButtonVisibility.Collapsed;
-			}
+        /// <summary>
+        /// Sets the visibility of the system UI's back button based on the navigation service.
+        /// </summary>
+        private void ConfigureSystemBackVisibility()
+        {
+            var navigationService = ServiceProvider.GetInstance<IStackNavigationService>();
 
-			navigationService.OnNavigated += OnNavigated;
-		}
+            void OnNavigated(IStackNavigationService sender, OnNavigatedEventArgs args)
+            {
+                SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility = sender.CanGoBack
+                    ? AppViewBackButtonVisibility.Visible
+                    : AppViewBackButtonVisibility.Collapsed;
+            }
 
-		/// <summary>
-		/// Hooks the system back button with the navigation service.
-		/// </summary>
-		private void ConfigureBackRequests()
-		{
-			void OnBackRequested(object sender, BackRequestedEventArgs e)
-			{
+            navigationService.OnNavigated += OnNavigated;
+        }
+
+        /// <summary>
+        /// Hooks the system back button with the navigation service.
+        /// </summary>
+        private void ConfigureBackRequests()
+        {
+            void OnBackRequested(object sender, BackRequestedEventArgs e)
+            {
                 // ShowPage hook back request
                 if ((_rootFrame.Content as FrameworkElement)?.DataContext is ShowPageViewModel showPage &&
                     showPage.Show.SelectedEpisode != null && showPage.IsNarrowAndSelected)
                 {
                     showPage.Show.DismissSelectedEpisode.Execute(null);
                     e.Handled = true;
-					//don't navigate back as NarrowAndSelected
+                    //don't navigate back as NarrowAndSelected
                     return;
                 }
 
-				var navigationService = ServiceProvider.GetInstance<IStackNavigationService>();
+                var navigationService = ServiceProvider.GetInstance<IStackNavigationService>();
 
-				if (navigationService.CanGoBack)
-				{
-					e.Handled = true;
+                if (navigationService.CanGoBack)
+                {
+                    e.Handled = true;
 
-					navigationService.GoBack();
+                    navigationService.GoBack();
 
-					return;
-				}
+                    return;
+                }
 
-				// MainPage hook back request
-				if ((_rootFrame.Content as FrameworkElement)?.DataContext is MainPageViewModel mainPage &&
-					mainPage.Show.SelectedEpisode != null)
-				{
-					mainPage.Show.DismissSelectedEpisode.Execute(null);
-					e.Handled = true;
-				}
-			}
+                // MainPage hook back request
+                if ((_rootFrame.Content as FrameworkElement)?.DataContext is MainPageViewModel mainPage &&
+                    mainPage.Show.SelectedEpisode != null)
+                {
+                    mainPage.Show.DismissSelectedEpisode.Execute(null);
+                    e.Handled = true;
+                }
+            }
 
-			SystemNavigationManager.GetForCurrentView().BackRequested += OnBackRequested;
-		}
+            SystemNavigationManager.GetForCurrentView().BackRequested += OnBackRequested;
+        }
 
-		private static bool _isActivityBackgroundCleared;
-		private static DisplayOrientations _previousOrientation;
-		public static void OnFullscreenChanged(bool isFullscreen)
-		{
+        private static bool _isActivityBackgroundCleared;
+        private static DisplayOrientations _previousOrientation;
+        public static void OnFullscreenChanged(bool isFullscreen)
+        {
 #if __ANDROID__
 			// This will reset the window background from the splashscreen to a black background.
 			if (isFullscreen && !_isActivityBackgroundCleared)
@@ -287,31 +302,32 @@ namespace Ch9
 			}
 #endif
 
-			if (DeviceInfo.Idiom == DeviceIdiom.Phone)
-			{
-				if (isFullscreen)
-				{
-					_previousOrientation = DisplayInformation.AutoRotationPreferences;
-					DisplayInformation.AutoRotationPreferences = DisplayOrientations.None;
-				}
-				else
-				{
-					DisplayInformation.AutoRotationPreferences = _previousOrientation;
-				}
-			}
-		}
+            if (DeviceInfo.Idiom == DeviceIdiom.Phone)
+            {
+                if (isFullscreen)
+                {
+                    if (DisplayInformation.AutoRotationPreferences == DisplayOrientations.None) return;
 
-		/// <summary>
-		/// Configures global logging
-		/// </summary>
-		/// <param name="factory"></param>
-		static void ConfigureFilters(ILoggerFactory factory)
-		{
-			factory
-				.WithFilter(new FilterLoggerSettings
-					{
-						{ "Uno", Microsoft.Extensions.Logging.LogLevel.Warning },
-						{ "Windows", Microsoft.Extensions.Logging.LogLevel.Warning },
+                    DisplayInformation.AutoRotationPreferences = DisplayOrientations.Landscape;
+                }
+                else
+                {
+                    DisplayInformation.AutoRotationPreferences = DisplayOrientations.Portrait;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Configures global logging
+        /// </summary>
+        /// <param name="factory"></param>
+        static void ConfigureFilters(ILoggerFactory factory)
+        {
+            factory
+                .WithFilter(new FilterLoggerSettings
+                    {
+                        { "Uno", Microsoft.Extensions.Logging.LogLevel.Warning },
+                        { "Windows", Microsoft.Extensions.Logging.LogLevel.Warning },
 
 						// Debug JS interop
 						// { "Uno.Foundation.WebAssemblyRuntime", LogLevel.Debug },
@@ -346,12 +362,12 @@ namespace Ch9
 						// { "Windows.UI.Xaml.Controls.BufferViewCache", LogLevel.Debug }, //Android
 						// { "Windows.UI.Xaml.Controls.VirtualizingPanelGenerator", LogLevel.Debug }, //WASM
 					}
-				)
+                )
 #if DEBUG
-				.AddConsole(Microsoft.Extensions.Logging.LogLevel.Debug);
+                .AddConsole(Microsoft.Extensions.Logging.LogLevel.Debug);
 #else
 				.AddConsole(Microsoft.Extensions.Logging.LogLevel.Information);
 #endif
-		}
-	}
+        }
+    }
 }

--- a/src/Ch9/Ch9.Shared/App.xaml.cs
+++ b/src/Ch9/Ch9.Shared/App.xaml.cs
@@ -179,6 +179,42 @@ namespace Ch9
 			{
 				DisplayInformation.AutoRotationPreferences = DisplayOrientations.Portrait;
 			}
+
+			void OnOrientationChanged(DisplayInformation displayInformation, object args)
+			{
+
+				if ((_rootFrame.Content as FrameworkElement)?.DataContext is ShowPageViewModel showPage)
+				{
+					ToVideoFullWindow(showPage.Show, displayInformation);
+				}
+				else if ((_rootFrame.Content as FrameworkElement)?.DataContext is MainPageViewModel mainPage)
+				{
+					ToVideoFullWindow(mainPage.Show, displayInformation);
+				}
+
+				
+			}
+
+			DisplayInformation.GetForCurrentView().OrientationChanged += OnOrientationChanged;
+		}
+
+		/// <summary>
+		/// Sets the video to fullWindow depending on screen orientation
+		/// </summary>
+		/// <param name="showVm">The show vm for which we will change its property IsVideoFullWindow</param>
+		/// <param name="displayInformation">The displayInformation for the current view</param>
+		private void ToVideoFullWindow(ShowViewModel showVm, DisplayInformation displayInformation)
+		{
+			if (displayInformation.CurrentOrientation == DisplayOrientations.Landscape || 
+			    displayInformation.CurrentOrientation == DisplayOrientations.LandscapeFlipped 
+			    && showVm != null)
+			{
+				showVm.IsVideoFullWindow = true;
+			}
+			else
+			{
+				showVm.IsVideoFullWindow = false;
+			}
 		}
 
 		/// <summary>

--- a/src/Ch9/Ch9.Shared/MainPage.xaml
+++ b/src/Ch9/Ch9.Shared/MainPage.xaml
@@ -40,7 +40,7 @@
 		</Grid.ColumnDefinitions>
 
 		<VisualStateManager.VisualStateGroups>
-			<VisualStateGroup>
+			<VisualStateGroup CurrentStateChanged="VisualStateGroupCurrentStateChanged">
 				<VisualState x:Name="WideAndSelected">
 					<VisualState.StateTriggers>
 						<triggers:CompositeStateTrigger Operator="And">

--- a/src/Ch9/Ch9.Shared/MainPage.xaml
+++ b/src/Ch9/Ch9.Shared/MainPage.xaml
@@ -40,7 +40,7 @@
 		</Grid.ColumnDefinitions>
 
 		<VisualStateManager.VisualStateGroups>
-			<VisualStateGroup CurrentStateChanged="VisualStateGroupCurrentStateChanged">
+			<VisualStateGroup>
 				<VisualState x:Name="WideAndSelected">
 					<VisualState.StateTriggers>
 						<triggers:CompositeStateTrigger Operator="And">

--- a/src/Ch9/Ch9.Shared/MainPage.xaml.cs
+++ b/src/Ch9/Ch9.Shared/MainPage.xaml.cs
@@ -8,7 +8,6 @@ using System.Runtime.InteropServices.WindowsRuntime;
 using System.Threading.Tasks;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
-using Windows.Graphics.Display;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
@@ -16,7 +15,6 @@ using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
-using Xamarin.Essentials;
 
 namespace Ch9
 {
@@ -54,14 +52,5 @@ namespace Ch9
 				listView.SelectedIndex = 0;
 			}
 		}
-
-		private void VisualStateGroupCurrentStateChanged(object sender, VisualStateChangedEventArgs e)
-		{
-			//Allow screen rotation for this particular state
-			if (e.NewState?.Name == "NarrowAndSelected" && DeviceInfo.Idiom == DeviceIdiom.Phone)
-			{
-				DisplayInformation.AutoRotationPreferences = DisplayOrientations.None;
-			}
-		}
-	}
+    }
 }

--- a/src/Ch9/Ch9.Shared/MainPage.xaml.cs
+++ b/src/Ch9/Ch9.Shared/MainPage.xaml.cs
@@ -8,6 +8,7 @@ using System.Runtime.InteropServices.WindowsRuntime;
 using System.Threading.Tasks;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
+using Windows.Graphics.Display;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
@@ -15,6 +16,7 @@ using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
+using Xamarin.Essentials;
 
 namespace Ch9
 {
@@ -50,6 +52,15 @@ namespace Ch9
 				Windows.UI.Xaml.Window.Current.Bounds.Width >= 800)
 			{
 				listView.SelectedIndex = 0;
+			}
+		}
+
+		private void VisualStateGroupCurrentStateChanged(object sender, VisualStateChangedEventArgs e)
+		{
+			//Allow screen rotation for this particular state
+			if (e.NewState?.Name == "NarrowAndSelected" && DeviceInfo.Idiom == DeviceIdiom.Phone)
+			{
+				DisplayInformation.AutoRotationPreferences = DisplayOrientations.None;
 			}
 		}
 	}

--- a/src/Ch9/Ch9.Shared/ShowPage.xaml.cs
+++ b/src/Ch9/Ch9.Shared/ShowPage.xaml.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Runtime.InteropServices.WindowsRuntime;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
-using Windows.Graphics.Display;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
@@ -17,7 +16,6 @@ using Windows.UI.Xaml.Navigation;
 using Ch9.Domain;
 using Ch9.ViewModels;
 using Windows.UI.Core;
-using Xamarin.Essentials;
 
 // The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
 
@@ -68,13 +66,7 @@ namespace Ch9
 			if (ViewModel != null)
 			{
 				ViewModel.IsNarrowAndSelected = e.NewState?.Name == "NarrowAndSelected";
-
-				//Allow screen rotation for this particular state
-				if (ViewModel.IsNarrowAndSelected && DeviceInfo.Idiom == DeviceIdiom.Phone)
-				{
-					DisplayInformation.AutoRotationPreferences = DisplayOrientations.None;
-				}
-			}
+            }
         }
 	}
 }

--- a/src/Ch9/Ch9.Shared/ShowPage.xaml.cs
+++ b/src/Ch9/Ch9.Shared/ShowPage.xaml.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Runtime.InteropServices.WindowsRuntime;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
+using Windows.Graphics.Display;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
@@ -16,6 +17,7 @@ using Windows.UI.Xaml.Navigation;
 using Ch9.Domain;
 using Ch9.ViewModels;
 using Windows.UI.Core;
+using Xamarin.Essentials;
 
 // The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
 
@@ -66,6 +68,12 @@ namespace Ch9
 			if (ViewModel != null)
 			{
 				ViewModel.IsNarrowAndSelected = e.NewState?.Name == "NarrowAndSelected";
+
+				//Allow screen rotation for this particular state
+				if (ViewModel.IsNarrowAndSelected && DeviceInfo.Idiom == DeviceIdiom.Phone)
+				{
+					DisplayInformation.AutoRotationPreferences = DisplayOrientations.None;
+				}
 			}
         }
 	}

--- a/src/Ch9/Ch9.Shared/Styles/Controls/MediaPlayerElement.xaml
+++ b/src/Ch9/Ch9.Shared/Styles/Controls/MediaPlayerElement.xaml
@@ -383,27 +383,7 @@
 							<!-- FullWindow states -->
 							<VisualStateGroup x:Name="FullWindowStates">
 								<VisualState x:Name="NonFullWindowState" />
-								<VisualState x:Name="FullWindowState">
-									<Storyboard>
-										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="FullScreenPanel"
-																	   Storyboard.TargetProperty="VerticalAlignment">
-											<DiscreteObjectKeyFrame KeyTime="0"
-																	Value="Top" />
-										</ObjectAnimationUsingKeyFrames>
-
-										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="FullWindowSymbol"
-																	   Storyboard.TargetProperty="Style">
-											<DiscreteObjectKeyFrame KeyTime="0"
-																	Value="{StaticResource BackToScreenIconPath}" />
-										</ObjectAnimationUsingKeyFrames>
-										
-										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="FullWindowSymbol"
-																	   Storyboard.TargetProperty="Data">
-											<DiscreteObjectKeyFrame KeyTime="0"
-																	Value="M18,16.6l7.5,7.5l-1.8,1.8l-7.5-7.5l-7.5,7.5l-1.8-1.8l7.5-7.5L6.8,9l1.8-1.8l7.7,7.7l7.7-7.7L25.6,9L18,16.6z" />
-										</ObjectAnimationUsingKeyFrames>
-									</Storyboard>
-								</VisualState>
+								<VisualState x:Name="FullWindowState" />
 							</VisualStateGroup>
 						</VisualStateManager.VisualStateGroups>
 


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

- Display orientation is set to Portrait in any pages of the app, unless the user forces full window mode through full screen button when playing video 
- Click on the full screen icon triggers a "Portrait full screen". 


## What is the new behavior?

- Display orientation is allowed to be landscape for phones (narrow mode) and triggers full screen video when orientation changes to any Landscape orientation.
- Click on the full screen icon now triggers a full landscape screen (same behavior as youtube)
- Removed FullWindowState logic, for it to behaves like all streaming platform, click on fullscreen window to load/unload the full window state.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
