### PR TITLE
Re-added lottie for uwp

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,210 @@
+﻿root = true
+
+#############################
+# Core EditorConfig Options #
+#############################
+
+[*]
+indent_style = tab
+end_of_line = crlf
+charset = utf-8-bom
+trim_trailing_whitespace = true
+
+# Code files
+[*.{cs,tt,xaml,xml,md,ps1}]
+indent_size = 4
+insert_final_newline = true
+
+# XML project files
+[*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]
+indent_size = 2
+
+# XML config files
+[*.{props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct}]
+indent_size = 2
+
+# YML configuration files
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2
+
+# JSON files
+[*.json]
+indent_size = 2
+
+###########################
+# .NET Coding Conventions #
+###########################
+
+[*.cs]
+# Organize usings
+dotnet_sort_system_directives_first = true
+dotnet_separate_import_directive_groups = false
+
+# Avoid the this. keyword
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_event = false:suggestion
+
+# Use language keywords instead of framework type names for type references
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+
+# Suggest more modern language features when available
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_auto_properties = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:suggestion
+dotnet_style_prefer_conditional_expression_over_return = true:suggestion
+
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:suggestion
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:suggestion
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:suggestion
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:suggestion
+
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:suggestion
+dotnet_style_readonly_field = true:suggestion
+
+######################
+# Naming Conventions #
+######################
+
+# Style Definitions
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+
+# Constant fields are PascalCase
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style = pascal_case_style
+dotnet_naming_symbols.constant_fields.applicable_kinds = field
+dotnet_naming_symbols.constant_fields.applicable_accessibilities = *
+dotnet_naming_symbols.constant_fields.required_modifiers = const
+
+# Non-private readonly fields are PascalCase
+dotnet_naming_rule.non_private_readonly_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.non_private_readonly_fields_should_be_pascal_case.symbols = non_private_readonly_fields
+dotnet_naming_rule.non_private_readonly_fields_should_be_pascal_case.style = non_private_readonly_field_style
+dotnet_naming_symbols.non_private_readonly_fields.applicable_kinds = field
+dotnet_naming_symbols.non_private_readonly_fields.applicable_accessibilities = public, protected, internal, protected internal, private protected
+dotnet_naming_symbols.non_private_readonly_fields.required_modifiers = readonly
+dotnet_naming_style.non_private_readonly_field_style.capitalization = pascal_case
+
+# Non-private static fields are PascalCase
+dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.symbols = non_private_static_fields
+dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.style = non_private_static_field_style
+dotnet_naming_symbols.non_private_static_fields.applicable_kinds = field
+dotnet_naming_symbols.non_private_static_fields.applicable_accessibilities = public, protected, internal, protected internal, private protected
+dotnet_naming_symbols.non_private_static_fields.required_modifiers = static
+dotnet_naming_style.non_private_static_field_style.capitalization = pascal_case
+
+# Private static fields are camelCase
+dotnet_naming_rule.static_fields_should_be_camel_case.severity = suggestion
+dotnet_naming_rule.static_fields_should_be_camel_case.symbols = static_fields
+dotnet_naming_rule.static_fields_should_be_camel_case.style = static_field_style
+dotnet_naming_symbols.static_fields.applicable_kinds = field
+dotnet_naming_symbols.static_fields.required_modifiers = static
+dotnet_naming_style.static_field_style.capitalization = camel_case
+dotnet_naming_style.static_field_style.required_prefix = _
+
+# Instance fields are camelCase and start with _
+dotnet_naming_rule.instance_fields_should_be_camel_case.severity = suggestion
+dotnet_naming_rule.instance_fields_should_be_camel_case.symbols = instance_fields
+dotnet_naming_rule.instance_fields_should_be_camel_case.style = instance_field_style
+dotnet_naming_symbols.instance_fields.applicable_kinds = field
+dotnet_naming_style.instance_field_style.capitalization = camel_case
+dotnet_naming_style.instance_field_style.required_prefix = _
+
+# Locals and parameters are camelCase
+dotnet_naming_rule.locals_should_be_camel_case.severity = suggestion
+dotnet_naming_rule.locals_should_be_camel_case.symbols = locals_and_parameters
+dotnet_naming_rule.locals_should_be_camel_case.style = camel_case_style
+dotnet_naming_symbols.locals_and_parameters.applicable_kinds = parameter, local
+dotnet_naming_style.camel_case_style.capitalization = camel_case
+
+# Local functions are PascalCase
+dotnet_naming_rule.local_functions_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.local_functions_should_be_pascal_case.symbols = local_functions
+dotnet_naming_rule.local_functions_should_be_pascal_case.style = local_function_style
+dotnet_naming_symbols.local_functions.applicable_kinds = local_function
+dotnet_naming_style.local_function_style.capitalization = pascal_case
+
+# By default, name items with PascalCase
+dotnet_naming_rule.members_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.members_should_be_pascal_case.symbols = all_members
+dotnet_naming_rule.members_should_be_pascal_case.style = pascal_case_style
+dotnet_naming_symbols.all_members.applicable_kinds = *
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+
+#######################
+# C# Code Style Rules #
+#######################
+
+# Indentation preferences
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = flush_left
+
+# Prefer "var" everywhere
+csharp_style_var_for_built_in_types = true:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_var_elsewhere = true:suggestion
+
+# Prefer property-like constructs to have an expression-body
+csharp_style_expression_bodied_properties = true:suggestion
+csharp_style_expression_bodied_indexers = true:suggestion
+csharp_style_expression_bodied_accessors = true:suggestion
+csharp_style_expression_bodied_methods = false:none
+csharp_style_expression_bodied_constructors = false:none
+csharp_style_expression_bodied_operators = false:none
+
+# Newline preferences
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+
+# Suggest more modern language features when available
+csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_style_pattern_local_over_anonymous_function = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+
+# Blocks are allowed
+csharp_prefer_braces = true:suggestion
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = true
+
+# Modifier preferences
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion
+
+# CS1591: Missing XML comment for publicly visible type or member
+dotnet_diagnostic.CS1591.severity = suggestion

--- a/src/Ch9/Ch9.Shared/MainPage.xaml
+++ b/src/Ch9/Ch9.Shared/MainPage.xaml
@@ -1,8 +1,7 @@
 ﻿<Page x:Class="Ch9.MainPage"
 	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	  xmlns:win="using:Uno.UI.Toolkit"
-	  xmlns:win2="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 	  xmlns:local="using:Ch9"
 	  xmlns:toolkit="using:Uno.UI.Toolkit"
 	  xmlns:ctoolkit="using:Microsoft.Toolkit.Uwp.UI.Controls"
@@ -10,13 +9,12 @@
 	  xmlns:lottie="using:Microsoft.Toolkit.Uwp.UI.Lottie"
 	  xmlns:winui="using:Microsoft.UI.Xaml.Controls"
 	  xmlns:android="http://Uno.UI/android"
-	  xmlns:xamarin="http://Uno.UI/xamarin"
-	  xmlns:triggers="using:WindowsStateTriggers"
-	  mc:Ignorable="android xamarin">
+      xmlns:triggers="using:WindowsStateTriggers"
+	  mc:Ignorable="android">
 
-	<Grid Background="{ThemeResource AppBackgroundBrush}">
+    <Grid Background="{ThemeResource AppBackgroundBrush}">
 
-		<!--           WIDE                     NARROW             NARROW 
+        <!--           WIDE                     NARROW             NARROW 
                                             (no selection)       (selection)
         
             | - - - - - - - - - - - -|     | - - - - - - |     | - - - - - - | 
@@ -26,275 +24,275 @@
             | - - - - - - - - - - - -|     | - - - - - - |     | - - - - - - | 
         -->
 
-		<Grid.RowDefinitions>
-			<RowDefinition Height="Auto" />
-			<RowDefinition Height="Auto" />
-			<RowDefinition Height="*" />
-		</Grid.RowDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
 
-		<Grid.ColumnDefinitions>
-			<ColumnDefinition x:Name="LeftColumn"
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition x:Name="LeftColumn"
 							  Width="*" />
-			<ColumnDefinition x:Name="RightColumn"
+            <ColumnDefinition x:Name="RightColumn"
 							  Width="0" />
-		</Grid.ColumnDefinitions>
+        </Grid.ColumnDefinitions>
 
-		<VisualStateManager.VisualStateGroups>
-			<VisualStateGroup>
-				<VisualState x:Name="WideAndSelected">
-					<VisualState.StateTriggers>
-						<triggers:CompositeStateTrigger Operator="And">
-							<triggers:AdaptiveTrigger MinWindowWidth="800" />
-							<StateTrigger IsActive="{x:Bind ViewModel.Show.SelectedEpisode, Converter={StaticResource NullToFalse}, Mode=OneWay}" />
-						</triggers:CompositeStateTrigger>
-					</VisualState.StateTriggers>
+        <VisualStateManager.VisualStateGroups>
+            <VisualStateGroup>
+                <VisualState x:Name="WideAndSelected">
+                    <VisualState.StateTriggers>
+                        <triggers:CompositeStateTrigger Operator="And">
+                            <triggers:AdaptiveTrigger MinWindowWidth="800" />
+                            <StateTrigger IsActive="{x:Bind ViewModel.Show.SelectedEpisode, Converter={StaticResource NullToFalse}, Mode=OneWay}" />
+                        </triggers:CompositeStateTrigger>
+                    </VisualState.StateTriggers>
 
-					<VisualState.Setters>
-						<Setter Target="LeftColumn.Width"
+                    <VisualState.Setters>
+                        <Setter Target="LeftColumn.Width"
 								Value="375" />
-						<Setter Target="RightColumn.Width"
+                        <Setter Target="RightColumn.Width"
 								Value="*" />
-						<Setter Target="EpisodePresenter.Row"
+                        <Setter Target="EpisodePresenter.Row"
 								Value="2" />
-						<Setter Target="EpisodePresenter.Column"
+                        <Setter Target="EpisodePresenter.Column"
 								Value="1" />
-						<Setter Target="EpisodePresenter.ColumnSpan"
+                        <Setter Target="EpisodePresenter.ColumnSpan"
 								Value="1" />
-						<Setter Target="EpisodePresenter.Row"
+                        <Setter Target="EpisodePresenter.Row"
 								Value="2" />
-						<Setter Target="EpisodePresenter.RowSpan"
+                        <Setter Target="EpisodePresenter.RowSpan"
 								Value="1" />
-						<Setter Target="EpisodePresenter.IsHitTestVisible"
+                        <Setter Target="EpisodePresenter.IsHitTestVisible"
 								Value="True" />
-						<Setter Target="ModalBackground.Visibility"
+                        <Setter Target="ModalBackground.Visibility"
 								Value="Collapsed" />
-						<Setter Target="DismissButton.Visibility"
+                        <Setter Target="DismissButton.Visibility"
 								Value="Collapsed" />
-						<Setter Target="EpisodeList.Padding"
+                        <Setter Target="EpisodeList.Padding"
 								Value="12,0" />
-					</VisualState.Setters>
-				</VisualState>
+                    </VisualState.Setters>
+                </VisualState>
 
-				<VisualState x:Name="WideAndNotSelected">
-					<VisualState.StateTriggers>
-						<triggers:CompositeStateTrigger Operator="And">
-							<triggers:AdaptiveTrigger MinWindowWidth="800" />
-							<StateTrigger IsActive="{x:Bind ViewModel.Show.SelectedEpisode, Converter={StaticResource NullToTrue}, Mode=OneWay}" />
-						</triggers:CompositeStateTrigger>
-					</VisualState.StateTriggers>
+                <VisualState x:Name="WideAndNotSelected">
+                    <VisualState.StateTriggers>
+                        <triggers:CompositeStateTrigger Operator="And">
+                            <triggers:AdaptiveTrigger MinWindowWidth="800" />
+                            <StateTrigger IsActive="{x:Bind ViewModel.Show.SelectedEpisode, Converter={StaticResource NullToTrue}, Mode=OneWay}" />
+                        </triggers:CompositeStateTrigger>
+                    </VisualState.StateTriggers>
 
-					<VisualState.Setters>
-						<Setter Target="LeftColumn.Width"
+                    <VisualState.Setters>
+                        <Setter Target="LeftColumn.Width"
 								Value="375" />
-						<Setter Target="RightColumn.Width"
+                        <Setter Target="RightColumn.Width"
 								Value="*" />
-						<Setter Target="EpisodePresenter.Row"
+                        <Setter Target="EpisodePresenter.Row"
 								Value="2" />
-						<Setter Target="EpisodePresenter.Column"
+                        <Setter Target="EpisodePresenter.Column"
 								Value="1" />
-						<Setter Target="EpisodePresenter.ColumnSpan"
+                        <Setter Target="EpisodePresenter.ColumnSpan"
 								Value="1" />
-						<Setter Target="EpisodePresenter.Row"
+                        <Setter Target="EpisodePresenter.Row"
 								Value="2" />
-						<Setter Target="EpisodePresenter.RowSpan"
+                        <Setter Target="EpisodePresenter.RowSpan"
 								Value="1" />
-						<Setter Target="ModalBackground.Visibility"
+                        <Setter Target="ModalBackground.Visibility"
 								Value="Collapsed" />
-						<Setter Target="DismissButton.Visibility"
+                        <Setter Target="DismissButton.Visibility"
 								Value="Collapsed" />
-						<Setter Target="EpisodeList.Padding"
+                        <Setter Target="EpisodeList.Padding"
 								Value="12,0" />
-					</VisualState.Setters>
-				</VisualState>
+                    </VisualState.Setters>
+                </VisualState>
 
-				<VisualState x:Name="NarrowAndSelected">
-					<VisualState.StateTriggers>
-						<triggers:CompositeStateTrigger Operator="And">
-							<StateTrigger IsActive="{x:Bind ViewModel.Show.SelectedEpisode, Converter={StaticResource NullToFalse}, Mode=OneWay}" />
-						</triggers:CompositeStateTrigger>
-					</VisualState.StateTriggers>
+                <VisualState x:Name="NarrowAndSelected">
+                    <VisualState.StateTriggers>
+                        <triggers:CompositeStateTrigger Operator="And">
+                            <StateTrigger IsActive="{x:Bind ViewModel.Show.SelectedEpisode, Converter={StaticResource NullToFalse}, Mode=OneWay}" />
+                        </triggers:CompositeStateTrigger>
+                    </VisualState.StateTriggers>
 
-					<VisualState.Setters>
-						<Setter Target="CommandBar.Visibility"
+                    <VisualState.Setters>
+                        <Setter Target="CommandBar.Visibility"
 								Value="Collapsed" />
-						<Setter Target="EpisodePresenter.IsHitTestVisible"
+                        <Setter Target="EpisodePresenter.IsHitTestVisible"
 								Value="True" />
-					</VisualState.Setters>
-				</VisualState>
-			</VisualStateGroup>
-		</VisualStateManager.VisualStateGroups>
+                    </VisualState.Setters>
+                </VisualState>
+            </VisualStateGroup>
+        </VisualStateManager.VisualStateGroups>
 
-		<!-- Command Bar -->
-		<CommandBar x:Name="CommandBar"
+        <!-- Command Bar -->
+        <CommandBar x:Name="CommandBar"
 					Style="{StaticResource ImageCommandBarStyle}"
 					Grid.Row="0"
 					Grid.ColumnSpan="2">
 
-			<CommandBar.PrimaryCommands>
-				<AppBarButton Command="{Binding ToAboutPage}"
+            <CommandBar.PrimaryCommands>
+                <AppBarButton Command="{Binding ToAboutPage}"
 							  android:Margin="0,0,16,0">
-					<Path Style="{StaticResource InfoIconPath}"
+                    <Path Style="{StaticResource InfoIconPath}"
 						  Fill="{StaticResource CommandBarForegroundBrush}"
 						  VerticalAlignment="Center" />
-				</AppBarButton>
-			</CommandBar.PrimaryCommands>
-		</CommandBar>
+                </AppBarButton>
+            </CommandBar.PrimaryCommands>
+        </CommandBar>
 
-		<Grid x:Name="NavigationTabsContainer"
+        <Grid x:Name="NavigationTabsContainer"
 			  Background="{StaticResource Color02Brush}"
 			  Grid.Row="1"
 			  Grid.ColumnSpan="2">
-			<Grid.ColumnDefinitions>
-				<ColumnDefinition Width="*" />
-				<ColumnDefinition Width="*" />
-			</Grid.ColumnDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
 
-			<!-- Fresh content View Tab -->
-			<RadioButton x:Name="FreshContentBtn"
+            <!-- Fresh content View Tab -->
+            <RadioButton x:Name="FreshContentBtn"
 						 GroupName="ViewTabsThin"
 						 Content="Recent"
 						 x:Uid="MainPage_Recent"
 						 IsChecked="True"
 						 Grid.Column="0" />
 
-			<!-- Shows View Tab -->
-			<RadioButton x:Name="ShowContentBtn"
+            <!-- Shows View Tab -->
+            <RadioButton x:Name="ShowContentBtn"
 						 GroupName="ViewTabsThin"
 						 Content="Shows"
 						 x:Uid="MainPage_Shows"
 						 Grid.Column="1" />
-		</Grid>
+        </Grid>
 
-		<!-- Shows list view -->
-		<GridView ItemsSource="{Binding Shows}"
+        <!-- Shows list view -->
+        <GridView ItemsSource="{Binding Shows}"
 				  Opacity="{Binding IsChecked, ElementName=ShowContentBtn, Converter={StaticResource TrueToOpaque}}"
 				  Style="{StaticResource DefaultGridViewStyle}"
 				  HorizontalAlignment="Center"
 				  Grid.Row="2"
 				  Grid.Column="0"
 				  Grid.ColumnSpan="2">
-			<GridView.ItemTemplate>
-				<DataTemplate>
+            <GridView.ItemTemplate>
+                <DataTemplate>
 
-					<Button Command="{Binding Parent.DisplayShow}"
+                    <Button Command="{Binding Parent.DisplayShow}"
 							CommandParameter="{Binding Show}"
 							Style="{StaticResource HiddenButtonStyle}">
 
-						<toolkit:ElevatedView Background="{StaticResource Color02Brush}"
+                        <toolkit:ElevatedView Background="{StaticResource Color02Brush}"
 											  win:BorderBrush="{StaticResource ShadowBrush}"
 											  win:BorderThickness="1"
 											  CornerRadius="9"
 											  Elevation="8"
 											  Margin="16,16,12,8">
-							<Grid Background="{StaticResource Color02Brush}">
-								<StackPanel>
+                            <Grid Background="{StaticResource Color02Brush}">
+                                <StackPanel>
 
-									<!-- Image -->
-									<Border Background="{StaticResource Color07Brush}"
+                                    <!-- Image -->
+                                    <Border Background="{StaticResource Color07Brush}"
 											CornerRadius="8,8,0,0">
-										<Image Source="{Binding Show.Image}"
+                                        <Image Source="{Binding Show.Image}"
 											   Stretch="UniformToFill"
 											   Height="200"
 											   Width="355" />
-									</Border>
+                                    </Border>
 
-									<!-- Label -->
-									<TextBlock Text="{Binding Show.Name}"
+                                    <!-- Label -->
+                                    <TextBlock Text="{Binding Show.Name}"
 											   Style="{StaticResource Typo02}"
 											   Margin="12,8,0,16" />
-								</StackPanel>
-							</Grid>
-						</toolkit:ElevatedView>
-					</Button>
-				</DataTemplate>
-			</GridView.ItemTemplate>
-		</GridView>
+                                </StackPanel>
+                            </Grid>
+                        </toolkit:ElevatedView>
+                    </Button>
+                </DataTemplate>
+            </GridView.ItemTemplate>
+        </GridView>
 
-		<!-- Episodes list -->
-		<Grid DataContext="{Binding Show}"
+        <!-- Episodes list -->
+        <Grid DataContext="{Binding Show}"
 			  Opacity="{Binding IsChecked, ElementName=FreshContentBtn, Converter={StaticResource TrueToOpaque}}"
 			  IsHitTestVisible="{Binding IsChecked, ElementName=FreshContentBtn}"
 			  Grid.Row="2"
 			  Grid.Column="0">
 
-			<!-- Content -->
-			<Grid Visibility="{Binding Show.IsSuccess, Converter={StaticResource TrueToVisible}, FallbackValue=Visible}">
+            <!-- Content -->
+            <Grid Visibility="{Binding Show.IsSuccess, Converter={StaticResource TrueToVisible}, FallbackValue=Visible}">
 
-				<!-- List of episodes -->
-				<ListView x:Name="EpisodeList"
+                <!-- List of episodes -->
+                <ListView x:Name="EpisodeList"
 						  ItemsSource="{Binding Episodes}"
 						  ItemTemplate="{StaticResource EpisodeItemTemplate}"
 						  SelectionMode="Single"
 						  SelectedItem="{Binding SelectedEpisode, Mode=TwoWay}"
 						  ItemContainerStyle="{StaticResource EpisodeListViewItemStyle}">
-					<ListView.FooterTemplate>
-						<DataTemplate>
-							<StackPanel Margin="32,22,32,0">
+                    <ListView.FooterTemplate>
+                        <DataTemplate>
+                            <StackPanel Margin="32,22,32,0">
 
-								<!-- Foorter Message -->
-								<TextBlock Text="That's all the recent shows!"
+                                <!-- Foorter Message -->
+                                <TextBlock Text="That's all the recent shows!"
 										   x:Uid="MainPage_FooterMessage1"
 										   Style="{StaticResource Typo03}"
 										   TextAlignment="Center" />
 
-								<!-- Foorter Message -->
-								<TextBlock Text="For more, check out the 'Shows' tab."
+                                <!-- Foorter Message -->
+                                <TextBlock Text="For more, check out the 'Shows' tab."
 										   x:Uid="MainPage_FooterMessage2"
 										   Style="{StaticResource Typo03}"
 										   TextAlignment="Center" />
-							</StackPanel>
-						</DataTemplate>
-					</ListView.FooterTemplate>
-				</ListView>
+                            </StackPanel>
+                        </DataTemplate>
+                    </ListView.FooterTemplate>
+                </ListView>
 
-				<!-- Empty List Message -->
-				<TextBlock Visibility="{Binding Episodes, Converter={StaticResource EnumerableHasAnyToCollapsed}, FallbackValue=Collapsed}"
+                <!-- Empty List Message -->
+                <TextBlock Visibility="{Binding Episodes, Converter={StaticResource EnumerableHasAnyToCollapsed}, FallbackValue=Collapsed}"
 						   Text="Nothing to show"
 						   x:Uid="MainPage_EmptyListMessage"
 						   Style="{StaticResource Typo02}"
 						   TextAlignment="Center"
 						   VerticalAlignment="Center"
 						   Margin="16,0" />
-			</Grid>
-		</Grid>
+            </Grid>
+        </Grid>
 
-		<!-- No Selection -->
-		<Grid DataContext="{Binding Show}"
+        <!-- No Selection -->
+        <Grid DataContext="{Binding Show}"
 			  Visibility="{Binding IsChecked, ElementName=FreshContentBtn, Converter={StaticResource TrueToVisible}}"
 			  Grid.Row="2"
 			  Grid.Column="1">
 
-			<Grid Visibility="{Binding SelectedEpisode, Converter={StaticResource NullToVisible}}"
+            <Grid Visibility="{Binding SelectedEpisode, Converter={StaticResource NullToVisible}}"
 				  Background="{StaticResource Color02Brush}">
 
-				<StackPanel VerticalAlignment="Center">
+                <StackPanel VerticalAlignment="Center">
 
-					<!-- Image -->
-					<Image Source="ms-appx:///Assets/NoVideoSelectedIllustration.png"
+                    <!-- Image -->
+                    <Image Source="ms-appx:///Assets/NoVideoSelectedIllustration.png"
 						   Stretch="Uniform"
 						   Width="280"
 						   HorizontalAlignment="Center" />
 
-					<!-- Title -->
-					<TextBlock Text="No video selected"
+                    <!-- Title -->
+                    <TextBlock Text="No video selected"
 							   x:Uid="MainPage_NoSelectionTitle"
 							   Style="{StaticResource Typo02}"
 							   TextAlignment="Center"
 							   Margin="32,16,32,0" />
 
-					<!-- Message -->
-					<TextBlock Text="Channel 9 videos are both informative and entertaining, give them a try by selecting one from the list!"
+                    <!-- Message -->
+                    <TextBlock Text="Channel 9 videos are both informative and entertaining, give them a try by selecting one from the list!"
 							   x:Uid="MainPage_NoSelectionMessage"
 							   Style="{StaticResource Typo03}"
 							   TextAlignment="Center"
 							   MaxWidth="380"
 							   Margin="32,8,32,0" />
-				</StackPanel>
-			</Grid>
-		</Grid>
+                </StackPanel>
+            </Grid>
+        </Grid>
 
-		<!-- Selected Episode -->
-		<Grid x:Name="EpisodePresenter"
+        <!-- Selected Episode -->
+        <Grid x:Name="EpisodePresenter"
 			  DataContext="{Binding Show}"
 			  Visibility="{Binding IsChecked, ElementName=FreshContentBtn, Converter={StaticResource TrueToVisible}}"
 			  IsHitTestVisible="False"
@@ -303,38 +301,38 @@
 			  Grid.Column="0"
 			  Grid.ColumnSpan="2">
 
-			<Grid Visibility="{Binding SelectedEpisode, Converter={StaticResource NullToCollapsed}, FallbackValue=Collapsed}"
+            <Grid Visibility="{Binding SelectedEpisode, Converter={StaticResource NullToCollapsed}, FallbackValue=Collapsed}"
 				  toolkit:VisibleBoundsPadding.PaddingMask="Top"
 				  Background="{StaticResource Color02Brush}">
 
-				<!-- Modal background -->
-				<Border x:Name="ModalBackground"
+                <!-- Modal background -->
+                <Border x:Name="ModalBackground"
 						Background="{StaticResource Color02Brush}" />
 
-				<!-- Presenter -->
-				<ScrollViewer>
+                <!-- Presenter -->
+                <ScrollViewer>
 
-					<!-- Episode -->
-					<local:EpisodeContent DataContext="{Binding SelectedEpisode}"
+                    <!-- Episode -->
+                    <local:EpisodeContent DataContext="{Binding SelectedEpisode}"
 										  VerticalAlignment="Top" />
-				</ScrollViewer>
+                </ScrollViewer>
 
-				<!-- Dismiss button -->
-				<Button x:Name="DismissButton"
+                <!-- Dismiss button -->
+                <Button x:Name="DismissButton"
 						Command="{Binding DismissSelectedEpisode}"
 						Style="{StaticResource VideoPlayerButtonStyle}"
 						HorizontalAlignment="Right"
 						VerticalAlignment="Top"
 						Margin="8,8,16,8">
-					<Path Style="{StaticResource CloseIconPath}"
+                    <Path Style="{StaticResource CloseIconPath}"
 						  Data="M21.976 2.438L23.563 4.024 14.586 13 23.563 21.976 21.976 23.563 13 14.586 4.024 23.563 2.438 21.976 11.413 13 2.438 4.024 4.024 2.438 13 11.413z"
 						  VerticalAlignment="Center" />
-				</Button>
-			</Grid>
-		</Grid>
+                </Button>
+            </Grid>
+        </Grid>
 
-		<!-- Error -->
-		<Grid DataContext="{Binding Show}"
+        <!-- Error -->
+        <Grid DataContext="{Binding Show}"
 			  Visibility="{Binding Show.IsFaulted, Converter={StaticResource TrueToVisible}, FallbackValue=Collapsed}"
 			  Background="{StaticResource Color08Brush}"
 			  Grid.Row="1"
@@ -342,66 +340,59 @@
 			  Grid.Column="0"
 			  Grid.ColumnSpan="2">
 
-			<StackPanel VerticalAlignment="Center">
+            <StackPanel VerticalAlignment="Center">
 
-				<!-- Image -->
-				<Image Source="{Binding Show.IsInternetFaulted, Converter={StaticResource HasNetworkErrorToErrorImage}}"
+                <!-- Image -->
+                <Image Source="{Binding Show.IsInternetFaulted, Converter={StaticResource HasNetworkErrorToErrorImage}}"
 					   Stretch="None"
 					   HorizontalAlignment="Center"
 					   Margin="{Binding Show.IsInternetFaulted, Converter={StaticResource HasNetworkErrorToErrorImageMargin}}" />
 
-				<!-- Title -->
-				<TextBlock Text="{Binding Show.IsInternetFaulted, Converter={StaticResource HasNetworkErrorToErrorTitle}}"
+                <!-- Title -->
+                <TextBlock Text="{Binding Show.IsInternetFaulted, Converter={StaticResource HasNetworkErrorToErrorTitle}}"
 						   Style="{StaticResource Typo02}"
 						   TextAlignment="Center"
 						   Margin="40,12,40,0" />
 
-				<!-- Message -->
-				<TextBlock Text="{Binding Show.IsInternetFaulted, Converter={StaticResource HasNetworkErrorToErrorMessage}}"
+                <!-- Message -->
+                <TextBlock Text="{Binding Show.IsInternetFaulted, Converter={StaticResource HasNetworkErrorToErrorMessage}}"
 						   Style="{StaticResource Typo03}"
 						   TextAlignment="Center"
 						   Margin="40,8,40,0" />
 
-				<!-- Reload button -->
-				<Button Content="Try Again"
+                <!-- Reload button -->
+                <Button Content="Try Again"
 						x:Uid="MainPage_ErrorStateButtonLabel"
 						Command="{Binding ReloadPage}"
 						Style="{StaticResource ErrorStateButtonStyle}"
 						Margin="40,40,40,0" />
-			</StackPanel>
-		</Grid>
+            </StackPanel>
+        </Grid>
 
-		<!-- Loading -->
-		<Grid Visibility="{Binding Show.IsExecuting, Converter={StaticResource TrueToVisible}, FallbackValue=Collapsed}"
+        <!-- Loading -->
+        <Grid Visibility="{Binding Show.IsExecuting, Converter={StaticResource TrueToVisible}, FallbackValue=Collapsed}"
 			  Background="{ThemeResource AppBackgroundBrush}"
 			  DataContext="{Binding Show}"
 			  Grid.Row="1"
 			  Grid.RowSpan="2"
 			  Grid.Column="0"
 			  Grid.ColumnSpan="2">
-			<StackPanel VerticalAlignment="Center"
+            <StackPanel VerticalAlignment="Center"
 						HorizontalAlignment="Center">
 
-				<!-- Loading Animation -->
-				<xamarin:Grid>
-					<winui:AnimatedVisualPlayer x:Name="player"
+                <!-- Loading Animation -->
+                <winui:AnimatedVisualPlayer x:Name="player"
 												AutoPlay="true"
 												Height="120">
-						<lottie:LottieVisualSource UriSource="ms-appx:///Lottie/loading_animation_data.json" />
-					</winui:AnimatedVisualPlayer>
-				</xamarin:Grid>
+                    <lottie:LottieVisualSource UriSource="ms-appx:///Lottie/loading_animation_data.json" />
+                </winui:AnimatedVisualPlayer>
 
-				<win2:Image Source="ms-appx:///Assets/NoVideoSelectedIllustration.png"
-						   Stretch="Uniform"
-						   Height="120"
-						   HorizontalAlignment="Center" />
-				
-				<!-- Loading Message -->
-				<TextBlock Text="Loading..."
+                <!-- Loading Message -->
+                <TextBlock Text="Loading..."
 						   x:Uid="MainPage_Loading"
 						   Style="{StaticResource Typo01}"
 						   TextAlignment="Center" />
-			</StackPanel>
-		</Grid>
-	</Grid>
+            </StackPanel>
+        </Grid>
+    </Grid>
 </Page>

--- a/src/Ch9/Ch9.Shared/MainPage.xaml
+++ b/src/Ch9/Ch9.Shared/MainPage.xaml
@@ -12,9 +12,9 @@
       xmlns:triggers="using:WindowsStateTriggers"
 	  mc:Ignorable="android">
 
-    <Grid Background="{ThemeResource AppBackgroundBrush}">
+	<Grid Background="{ThemeResource AppBackgroundBrush}">
 
-        <!--           WIDE                     NARROW             NARROW 
+		<!--           WIDE                     NARROW             NARROW 
                                             (no selection)       (selection)
         
             | - - - - - - - - - - - -|     | - - - - - - |     | - - - - - - | 
@@ -24,275 +24,275 @@
             | - - - - - - - - - - - -|     | - - - - - - |     | - - - - - - | 
         -->
 
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
-        </Grid.RowDefinitions>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
 
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition x:Name="LeftColumn"
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition x:Name="LeftColumn"
 							  Width="*" />
-            <ColumnDefinition x:Name="RightColumn"
+			<ColumnDefinition x:Name="RightColumn"
 							  Width="0" />
-        </Grid.ColumnDefinitions>
+		</Grid.ColumnDefinitions>
 
-        <VisualStateManager.VisualStateGroups>
-            <VisualStateGroup>
-                <VisualState x:Name="WideAndSelected">
-                    <VisualState.StateTriggers>
-                        <triggers:CompositeStateTrigger Operator="And">
-                            <triggers:AdaptiveTrigger MinWindowWidth="800" />
-                            <StateTrigger IsActive="{x:Bind ViewModel.Show.SelectedEpisode, Converter={StaticResource NullToFalse}, Mode=OneWay}" />
-                        </triggers:CompositeStateTrigger>
-                    </VisualState.StateTriggers>
+		<VisualStateManager.VisualStateGroups>
+			<VisualStateGroup>
+				<VisualState x:Name="WideAndSelected">
+					<VisualState.StateTriggers>
+						<triggers:CompositeStateTrigger Operator="And">
+							<triggers:AdaptiveTrigger MinWindowWidth="800" />
+							<StateTrigger IsActive="{x:Bind ViewModel.Show.SelectedEpisode, Converter={StaticResource NullToFalse}, Mode=OneWay}" />
+						</triggers:CompositeStateTrigger>
+					</VisualState.StateTriggers>
 
-                    <VisualState.Setters>
-                        <Setter Target="LeftColumn.Width"
+					<VisualState.Setters>
+						<Setter Target="LeftColumn.Width"
 								Value="375" />
-                        <Setter Target="RightColumn.Width"
+						<Setter Target="RightColumn.Width"
 								Value="*" />
-                        <Setter Target="EpisodePresenter.Row"
+						<Setter Target="EpisodePresenter.Row"
 								Value="2" />
-                        <Setter Target="EpisodePresenter.Column"
+						<Setter Target="EpisodePresenter.Column"
 								Value="1" />
-                        <Setter Target="EpisodePresenter.ColumnSpan"
+						<Setter Target="EpisodePresenter.ColumnSpan"
 								Value="1" />
-                        <Setter Target="EpisodePresenter.Row"
+						<Setter Target="EpisodePresenter.Row"
 								Value="2" />
-                        <Setter Target="EpisodePresenter.RowSpan"
+						<Setter Target="EpisodePresenter.RowSpan"
 								Value="1" />
-                        <Setter Target="EpisodePresenter.IsHitTestVisible"
+						<Setter Target="EpisodePresenter.IsHitTestVisible"
 								Value="True" />
-                        <Setter Target="ModalBackground.Visibility"
+						<Setter Target="ModalBackground.Visibility"
 								Value="Collapsed" />
-                        <Setter Target="DismissButton.Visibility"
+						<Setter Target="DismissButton.Visibility"
 								Value="Collapsed" />
-                        <Setter Target="EpisodeList.Padding"
+						<Setter Target="EpisodeList.Padding"
 								Value="12,0" />
-                    </VisualState.Setters>
-                </VisualState>
+					</VisualState.Setters>
+				</VisualState>
 
-                <VisualState x:Name="WideAndNotSelected">
-                    <VisualState.StateTriggers>
-                        <triggers:CompositeStateTrigger Operator="And">
-                            <triggers:AdaptiveTrigger MinWindowWidth="800" />
-                            <StateTrigger IsActive="{x:Bind ViewModel.Show.SelectedEpisode, Converter={StaticResource NullToTrue}, Mode=OneWay}" />
-                        </triggers:CompositeStateTrigger>
-                    </VisualState.StateTriggers>
+				<VisualState x:Name="WideAndNotSelected">
+					<VisualState.StateTriggers>
+						<triggers:CompositeStateTrigger Operator="And">
+							<triggers:AdaptiveTrigger MinWindowWidth="800" />
+							<StateTrigger IsActive="{x:Bind ViewModel.Show.SelectedEpisode, Converter={StaticResource NullToTrue}, Mode=OneWay}" />
+						</triggers:CompositeStateTrigger>
+					</VisualState.StateTriggers>
 
-                    <VisualState.Setters>
-                        <Setter Target="LeftColumn.Width"
+					<VisualState.Setters>
+						<Setter Target="LeftColumn.Width"
 								Value="375" />
-                        <Setter Target="RightColumn.Width"
+						<Setter Target="RightColumn.Width"
 								Value="*" />
-                        <Setter Target="EpisodePresenter.Row"
+						<Setter Target="EpisodePresenter.Row"
 								Value="2" />
-                        <Setter Target="EpisodePresenter.Column"
+						<Setter Target="EpisodePresenter.Column"
 								Value="1" />
-                        <Setter Target="EpisodePresenter.ColumnSpan"
+						<Setter Target="EpisodePresenter.ColumnSpan"
 								Value="1" />
-                        <Setter Target="EpisodePresenter.Row"
+						<Setter Target="EpisodePresenter.Row"
 								Value="2" />
-                        <Setter Target="EpisodePresenter.RowSpan"
+						<Setter Target="EpisodePresenter.RowSpan"
 								Value="1" />
-                        <Setter Target="ModalBackground.Visibility"
+						<Setter Target="ModalBackground.Visibility"
 								Value="Collapsed" />
-                        <Setter Target="DismissButton.Visibility"
+						<Setter Target="DismissButton.Visibility"
 								Value="Collapsed" />
-                        <Setter Target="EpisodeList.Padding"
+						<Setter Target="EpisodeList.Padding"
 								Value="12,0" />
-                    </VisualState.Setters>
-                </VisualState>
+					</VisualState.Setters>
+				</VisualState>
 
-                <VisualState x:Name="NarrowAndSelected">
-                    <VisualState.StateTriggers>
-                        <triggers:CompositeStateTrigger Operator="And">
-                            <StateTrigger IsActive="{x:Bind ViewModel.Show.SelectedEpisode, Converter={StaticResource NullToFalse}, Mode=OneWay}" />
-                        </triggers:CompositeStateTrigger>
-                    </VisualState.StateTriggers>
+				<VisualState x:Name="NarrowAndSelected">
+					<VisualState.StateTriggers>
+						<triggers:CompositeStateTrigger Operator="And">
+							<StateTrigger IsActive="{x:Bind ViewModel.Show.SelectedEpisode, Converter={StaticResource NullToFalse}, Mode=OneWay}" />
+						</triggers:CompositeStateTrigger>
+					</VisualState.StateTriggers>
 
-                    <VisualState.Setters>
-                        <Setter Target="CommandBar.Visibility"
+					<VisualState.Setters>
+						<Setter Target="CommandBar.Visibility"
 								Value="Collapsed" />
-                        <Setter Target="EpisodePresenter.IsHitTestVisible"
+						<Setter Target="EpisodePresenter.IsHitTestVisible"
 								Value="True" />
-                    </VisualState.Setters>
-                </VisualState>
-            </VisualStateGroup>
-        </VisualStateManager.VisualStateGroups>
+					</VisualState.Setters>
+				</VisualState>
+			</VisualStateGroup>
+		</VisualStateManager.VisualStateGroups>
 
-        <!-- Command Bar -->
-        <CommandBar x:Name="CommandBar"
+		<!-- Command Bar -->
+		<CommandBar x:Name="CommandBar"
 					Style="{StaticResource ImageCommandBarStyle}"
 					Grid.Row="0"
 					Grid.ColumnSpan="2">
 
-            <CommandBar.PrimaryCommands>
-                <AppBarButton Command="{Binding ToAboutPage}"
+			<CommandBar.PrimaryCommands>
+				<AppBarButton Command="{Binding ToAboutPage}"
 							  android:Margin="0,0,16,0">
-                    <Path Style="{StaticResource InfoIconPath}"
+					<Path Style="{StaticResource InfoIconPath}"
 						  Fill="{StaticResource CommandBarForegroundBrush}"
 						  VerticalAlignment="Center" />
-                </AppBarButton>
-            </CommandBar.PrimaryCommands>
-        </CommandBar>
+				</AppBarButton>
+			</CommandBar.PrimaryCommands>
+		</CommandBar>
 
-        <Grid x:Name="NavigationTabsContainer"
+		<Grid x:Name="NavigationTabsContainer"
 			  Background="{StaticResource Color02Brush}"
 			  Grid.Row="1"
 			  Grid.ColumnSpan="2">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
+			<Grid.ColumnDefinitions>
+				<ColumnDefinition Width="*" />
+				<ColumnDefinition Width="*" />
+			</Grid.ColumnDefinitions>
 
-            <!-- Fresh content View Tab -->
-            <RadioButton x:Name="FreshContentBtn"
+			<!-- Fresh content View Tab -->
+			<RadioButton x:Name="FreshContentBtn"
 						 GroupName="ViewTabsThin"
 						 Content="Recent"
 						 x:Uid="MainPage_Recent"
 						 IsChecked="True"
 						 Grid.Column="0" />
 
-            <!-- Shows View Tab -->
-            <RadioButton x:Name="ShowContentBtn"
+			<!-- Shows View Tab -->
+			<RadioButton x:Name="ShowContentBtn"
 						 GroupName="ViewTabsThin"
 						 Content="Shows"
 						 x:Uid="MainPage_Shows"
 						 Grid.Column="1" />
-        </Grid>
+		</Grid>
 
-        <!-- Shows list view -->
-        <GridView ItemsSource="{Binding Shows}"
+		<!-- Shows list view -->
+		<GridView ItemsSource="{Binding Shows}"
 				  Opacity="{Binding IsChecked, ElementName=ShowContentBtn, Converter={StaticResource TrueToOpaque}}"
 				  Style="{StaticResource DefaultGridViewStyle}"
 				  HorizontalAlignment="Center"
 				  Grid.Row="2"
 				  Grid.Column="0"
 				  Grid.ColumnSpan="2">
-            <GridView.ItemTemplate>
-                <DataTemplate>
+			<GridView.ItemTemplate>
+				<DataTemplate>
 
-                    <Button Command="{Binding Parent.DisplayShow}"
+					<Button Command="{Binding Parent.DisplayShow}"
 							CommandParameter="{Binding Show}"
 							Style="{StaticResource HiddenButtonStyle}">
 
-                        <toolkit:ElevatedView Background="{StaticResource Color02Brush}"
+						<toolkit:ElevatedView Background="{StaticResource Color02Brush}"
 											  win:BorderBrush="{StaticResource ShadowBrush}"
 											  win:BorderThickness="1"
 											  CornerRadius="9"
 											  Elevation="8"
 											  Margin="16,16,12,8">
-                            <Grid Background="{StaticResource Color02Brush}">
-                                <StackPanel>
+							<Grid Background="{StaticResource Color02Brush}">
+								<StackPanel>
 
-                                    <!-- Image -->
-                                    <Border Background="{StaticResource Color07Brush}"
+									<!-- Image -->
+									<Border Background="{StaticResource Color07Brush}"
 											CornerRadius="8,8,0,0">
-                                        <Image Source="{Binding Show.Image}"
+										<Image Source="{Binding Show.Image}"
 											   Stretch="UniformToFill"
 											   Height="200"
 											   Width="355" />
-                                    </Border>
+									</Border>
 
-                                    <!-- Label -->
-                                    <TextBlock Text="{Binding Show.Name}"
+									<!-- Label -->
+									<TextBlock Text="{Binding Show.Name}"
 											   Style="{StaticResource Typo02}"
 											   Margin="12,8,0,16" />
-                                </StackPanel>
-                            </Grid>
-                        </toolkit:ElevatedView>
-                    </Button>
-                </DataTemplate>
-            </GridView.ItemTemplate>
-        </GridView>
+								</StackPanel>
+							</Grid>
+						</toolkit:ElevatedView>
+					</Button>
+				</DataTemplate>
+			</GridView.ItemTemplate>
+		</GridView>
 
-        <!-- Episodes list -->
-        <Grid DataContext="{Binding Show}"
+		<!-- Episodes list -->
+		<Grid DataContext="{Binding Show}"
 			  Opacity="{Binding IsChecked, ElementName=FreshContentBtn, Converter={StaticResource TrueToOpaque}}"
 			  IsHitTestVisible="{Binding IsChecked, ElementName=FreshContentBtn}"
 			  Grid.Row="2"
 			  Grid.Column="0">
 
-            <!-- Content -->
-            <Grid Visibility="{Binding Show.IsSuccess, Converter={StaticResource TrueToVisible}, FallbackValue=Visible}">
+			<!-- Content -->
+			<Grid Visibility="{Binding Show.IsSuccess, Converter={StaticResource TrueToVisible}, FallbackValue=Visible}">
 
-                <!-- List of episodes -->
-                <ListView x:Name="EpisodeList"
+				<!-- List of episodes -->
+				<ListView x:Name="EpisodeList"
 						  ItemsSource="{Binding Episodes}"
 						  ItemTemplate="{StaticResource EpisodeItemTemplate}"
 						  SelectionMode="Single"
 						  SelectedItem="{Binding SelectedEpisode, Mode=TwoWay}"
 						  ItemContainerStyle="{StaticResource EpisodeListViewItemStyle}">
-                    <ListView.FooterTemplate>
-                        <DataTemplate>
-                            <StackPanel Margin="32,22,32,0">
+					<ListView.FooterTemplate>
+						<DataTemplate>
+							<StackPanel Margin="32,22,32,0">
 
-                                <!-- Foorter Message -->
-                                <TextBlock Text="That's all the recent shows!"
+								<!-- Foorter Message -->
+								<TextBlock Text="That's all the recent shows!"
 										   x:Uid="MainPage_FooterMessage1"
 										   Style="{StaticResource Typo03}"
 										   TextAlignment="Center" />
 
-                                <!-- Foorter Message -->
-                                <TextBlock Text="For more, check out the 'Shows' tab."
+								<!-- Foorter Message -->
+								<TextBlock Text="For more, check out the 'Shows' tab."
 										   x:Uid="MainPage_FooterMessage2"
 										   Style="{StaticResource Typo03}"
 										   TextAlignment="Center" />
-                            </StackPanel>
-                        </DataTemplate>
-                    </ListView.FooterTemplate>
-                </ListView>
+							</StackPanel>
+						</DataTemplate>
+					</ListView.FooterTemplate>
+				</ListView>
 
-                <!-- Empty List Message -->
-                <TextBlock Visibility="{Binding Episodes, Converter={StaticResource EnumerableHasAnyToCollapsed}, FallbackValue=Collapsed}"
+				<!-- Empty List Message -->
+				<TextBlock Visibility="{Binding Episodes, Converter={StaticResource EnumerableHasAnyToCollapsed}, FallbackValue=Collapsed}"
 						   Text="Nothing to show"
 						   x:Uid="MainPage_EmptyListMessage"
 						   Style="{StaticResource Typo02}"
 						   TextAlignment="Center"
 						   VerticalAlignment="Center"
 						   Margin="16,0" />
-            </Grid>
-        </Grid>
+			</Grid>
+		</Grid>
 
-        <!-- No Selection -->
-        <Grid DataContext="{Binding Show}"
+		<!-- No Selection -->
+		<Grid DataContext="{Binding Show}"
 			  Visibility="{Binding IsChecked, ElementName=FreshContentBtn, Converter={StaticResource TrueToVisible}}"
 			  Grid.Row="2"
 			  Grid.Column="1">
 
-            <Grid Visibility="{Binding SelectedEpisode, Converter={StaticResource NullToVisible}}"
+			<Grid Visibility="{Binding SelectedEpisode, Converter={StaticResource NullToVisible}}"
 				  Background="{StaticResource Color02Brush}">
 
-                <StackPanel VerticalAlignment="Center">
+				<StackPanel VerticalAlignment="Center">
 
-                    <!-- Image -->
-                    <Image Source="ms-appx:///Assets/NoVideoSelectedIllustration.png"
+					<!-- Image -->
+					<Image Source="ms-appx:///Assets/NoVideoSelectedIllustration.png"
 						   Stretch="Uniform"
 						   Width="280"
 						   HorizontalAlignment="Center" />
 
-                    <!-- Title -->
-                    <TextBlock Text="No video selected"
+					<!-- Title -->
+					<TextBlock Text="No video selected"
 							   x:Uid="MainPage_NoSelectionTitle"
 							   Style="{StaticResource Typo02}"
 							   TextAlignment="Center"
 							   Margin="32,16,32,0" />
 
-                    <!-- Message -->
-                    <TextBlock Text="Channel 9 videos are both informative and entertaining, give them a try by selecting one from the list!"
+					<!-- Message -->
+					<TextBlock Text="Channel 9 videos are both informative and entertaining, give them a try by selecting one from the list!"
 							   x:Uid="MainPage_NoSelectionMessage"
 							   Style="{StaticResource Typo03}"
 							   TextAlignment="Center"
 							   MaxWidth="380"
 							   Margin="32,8,32,0" />
-                </StackPanel>
-            </Grid>
-        </Grid>
+				</StackPanel>
+			</Grid>
+		</Grid>
 
-        <!-- Selected Episode -->
-        <Grid x:Name="EpisodePresenter"
+		<!-- Selected Episode -->
+		<Grid x:Name="EpisodePresenter"
 			  DataContext="{Binding Show}"
 			  Visibility="{Binding IsChecked, ElementName=FreshContentBtn, Converter={StaticResource TrueToVisible}}"
 			  IsHitTestVisible="False"
@@ -301,38 +301,38 @@
 			  Grid.Column="0"
 			  Grid.ColumnSpan="2">
 
-            <Grid Visibility="{Binding SelectedEpisode, Converter={StaticResource NullToCollapsed}, FallbackValue=Collapsed}"
+			<Grid Visibility="{Binding SelectedEpisode, Converter={StaticResource NullToCollapsed}, FallbackValue=Collapsed}"
 				  toolkit:VisibleBoundsPadding.PaddingMask="Top"
 				  Background="{StaticResource Color02Brush}">
 
-                <!-- Modal background -->
-                <Border x:Name="ModalBackground"
+				<!-- Modal background -->
+				<Border x:Name="ModalBackground"
 						Background="{StaticResource Color02Brush}" />
 
-                <!-- Presenter -->
-                <ScrollViewer>
+				<!-- Presenter -->
+				<ScrollViewer>
 
-                    <!-- Episode -->
-                    <local:EpisodeContent DataContext="{Binding SelectedEpisode}"
+					<!-- Episode -->
+					<local:EpisodeContent DataContext="{Binding SelectedEpisode}"
 										  VerticalAlignment="Top" />
-                </ScrollViewer>
+				</ScrollViewer>
 
-                <!-- Dismiss button -->
-                <Button x:Name="DismissButton"
+				<!-- Dismiss button -->
+				<Button x:Name="DismissButton"
 						Command="{Binding DismissSelectedEpisode}"
 						Style="{StaticResource VideoPlayerButtonStyle}"
 						HorizontalAlignment="Right"
 						VerticalAlignment="Top"
 						Margin="8,8,16,8">
-                    <Path Style="{StaticResource CloseIconPath}"
+					<Path Style="{StaticResource CloseIconPath}"
 						  Data="M21.976 2.438L23.563 4.024 14.586 13 23.563 21.976 21.976 23.563 13 14.586 4.024 23.563 2.438 21.976 11.413 13 2.438 4.024 4.024 2.438 13 11.413z"
 						  VerticalAlignment="Center" />
-                </Button>
-            </Grid>
-        </Grid>
+				</Button>
+			</Grid>
+		</Grid>
 
-        <!-- Error -->
-        <Grid DataContext="{Binding Show}"
+		<!-- Error -->
+		<Grid DataContext="{Binding Show}"
 			  Visibility="{Binding Show.IsFaulted, Converter={StaticResource TrueToVisible}, FallbackValue=Collapsed}"
 			  Background="{StaticResource Color08Brush}"
 			  Grid.Row="1"
@@ -340,59 +340,59 @@
 			  Grid.Column="0"
 			  Grid.ColumnSpan="2">
 
-            <StackPanel VerticalAlignment="Center">
+			<StackPanel VerticalAlignment="Center">
 
-                <!-- Image -->
-                <Image Source="{Binding Show.IsInternetFaulted, Converter={StaticResource HasNetworkErrorToErrorImage}}"
+				<!-- Image -->
+				<Image Source="{Binding Show.IsInternetFaulted, Converter={StaticResource HasNetworkErrorToErrorImage}}"
 					   Stretch="None"
 					   HorizontalAlignment="Center"
 					   Margin="{Binding Show.IsInternetFaulted, Converter={StaticResource HasNetworkErrorToErrorImageMargin}}" />
 
-                <!-- Title -->
-                <TextBlock Text="{Binding Show.IsInternetFaulted, Converter={StaticResource HasNetworkErrorToErrorTitle}}"
+				<!-- Title -->
+				<TextBlock Text="{Binding Show.IsInternetFaulted, Converter={StaticResource HasNetworkErrorToErrorTitle}}"
 						   Style="{StaticResource Typo02}"
 						   TextAlignment="Center"
 						   Margin="40,12,40,0" />
 
-                <!-- Message -->
-                <TextBlock Text="{Binding Show.IsInternetFaulted, Converter={StaticResource HasNetworkErrorToErrorMessage}}"
+				<!-- Message -->
+				<TextBlock Text="{Binding Show.IsInternetFaulted, Converter={StaticResource HasNetworkErrorToErrorMessage}}"
 						   Style="{StaticResource Typo03}"
 						   TextAlignment="Center"
 						   Margin="40,8,40,0" />
 
-                <!-- Reload button -->
-                <Button Content="Try Again"
+				<!-- Reload button -->
+				<Button Content="Try Again"
 						x:Uid="MainPage_ErrorStateButtonLabel"
 						Command="{Binding ReloadPage}"
 						Style="{StaticResource ErrorStateButtonStyle}"
 						Margin="40,40,40,0" />
-            </StackPanel>
-        </Grid>
+			</StackPanel>
+		</Grid>
 
-        <!-- Loading -->
-        <Grid Visibility="{Binding Show.IsExecuting, Converter={StaticResource TrueToVisible}, FallbackValue=Collapsed}"
+		<!-- Loading -->
+		<Grid Visibility="{Binding Show.IsExecuting, Converter={StaticResource TrueToVisible}, FallbackValue=Collapsed}"
 			  Background="{ThemeResource AppBackgroundBrush}"
 			  DataContext="{Binding Show}"
 			  Grid.Row="1"
 			  Grid.RowSpan="2"
 			  Grid.Column="0"
 			  Grid.ColumnSpan="2">
-            <StackPanel VerticalAlignment="Center"
+			<StackPanel VerticalAlignment="Center"
 						HorizontalAlignment="Center">
 
-                <!-- Loading Animation -->
-                <winui:AnimatedVisualPlayer x:Name="player"
+				<!-- Loading Animation -->
+				<winui:AnimatedVisualPlayer x:Name="player"
 												AutoPlay="true"
 												Height="120">
-                    <lottie:LottieVisualSource UriSource="ms-appx:///Lottie/loading_animation_data.json" />
-                </winui:AnimatedVisualPlayer>
+					<lottie:LottieVisualSource UriSource="ms-appx:///Lottie/loading_animation_data.json" />
+				</winui:AnimatedVisualPlayer>
 
-                <!-- Loading Message -->
-                <TextBlock Text="Loading..."
+				<!-- Loading Message -->
+				<TextBlock Text="Loading..."
 						   x:Uid="MainPage_Loading"
 						   Style="{StaticResource Typo01}"
 						   TextAlignment="Center" />
-            </StackPanel>
-        </Grid>
-    </Grid>
+			</StackPanel>
+		</Grid>
+	</Grid>
 </Page>

--- a/src/Ch9/Ch9.UWP/Ch9.UWP.csproj
+++ b/src/Ch9/Ch9.UWP/Ch9.UWP.csproj
@@ -115,6 +115,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
+    <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Lottie" Version="6.1.0" />
     <PackageReference Include="Microsoft.UI.Xaml" Version="2.4.2" />
     <PackageReference Include="System.ServiceModel.Syndication" Version="4.7.0" />
     <PackageReference Include="Uno.UI" Version="2.3.0-dev.90" />


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

Re added lottie for uwp => https://github.com/windows-toolkit/Lottie-Windows/issues/214


## What is the current behavior?

- Static image for loading


## What is the new behavior?

- Loading done through lottie on UWP 


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
