### PR TITLE
feat: Restores the Lottie animation on UWP in the Show page.

### DIFF
--- a/src/Ch9/Ch9.Shared/ShowPage.xaml
+++ b/src/Ch9/Ch9.Shared/ShowPage.xaml
@@ -7,9 +7,7 @@
 	  xmlns:triggers="using:WindowsStateTriggers"
 	  xmlns:toolkit="using:Uno.UI.Toolkit"
 	  xmlns:lottie="using:Microsoft.Toolkit.Uwp.UI.Lottie"
-	  xmlns:winui="using:Microsoft.UI.Xaml.Controls"		
-	  xmlns:xamarin="http://Uno.UI/xamarin"
-	  mc:Ignorable="xamarin">
+	  xmlns:winui="using:Microsoft.UI.Xaml.Controls">
 
 	<Page.Resources>
 		<DataTemplate x:Key="ShowDetailsTemplate">
@@ -333,18 +331,11 @@
 						HorizontalAlignment="Center">
 
 				<!-- Loading Animation -->
-				<xamarin:Grid>
-					<winui:AnimatedVisualPlayer x:Name="player"
-												AutoPlay="true"
-												Height="120">
-						<lottie:LottieVisualSource UriSource="ms-appx:///Lottie/loading_animation_data.json" />
-					</winui:AnimatedVisualPlayer>
-				</xamarin:Grid>
-
-				<win:Image Source="ms-appx:///Assets/NoVideoSelectedIllustration.png"
-						   Stretch="Uniform"
-						   Height="120"
-						   HorizontalAlignment="Center" />
+				<winui:AnimatedVisualPlayer x:Name="player"
+											AutoPlay="true"
+											Height="120">
+					<lottie:LottieVisualSource UriSource="ms-appx:///Lottie/loading_animation_data.json" />
+				</winui:AnimatedVisualPlayer>
 
 				<!-- Loading Message -->
 				<TextBlock Text="Loading..."

--- a/src/Ch9/Ch9.Shared/ShowPage.xaml
+++ b/src/Ch9/Ch9.Shared/ShowPage.xaml
@@ -1,13 +1,14 @@
 ﻿<Page x:Class="Ch9.ShowPage"
-	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-	  xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-	  xmlns:local="using:Ch9"
-	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-	  xmlns:triggers="using:WindowsStateTriggers"
-	  xmlns:toolkit="using:Uno.UI.Toolkit"
-	  xmlns:lottie="using:Microsoft.Toolkit.Uwp.UI.Lottie"
-	  xmlns:winui="using:Microsoft.UI.Xaml.Controls">
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:win="using:Uno.UI.Toolkit"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:local="using:Ch9"
+      xmlns:toolkit="using:Uno.UI.Toolkit"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:lottie="using:Microsoft.Toolkit.Uwp.UI.Lottie"
+      xmlns:winui="using:Microsoft.UI.Xaml.Controls"
+      xmlns:triggers="using:WindowsStateTriggers"
+      mc:Ignorable="">
 
 	<Page.Resources>
 		<DataTemplate x:Key="ShowDetailsTemplate">


### PR DESCRIPTION
## PR Type
- Feature

## What is the current behavior?
Lottie animation was removed on UWP for the store submission.


## What is the new behavior?
Lottie animation was restored on UWP since there should be an exception for the Ch9 app.
