### PR TITLE
[BugFixing] Android back button & ios expand button

### DIFF
--- a/src/Ch9/Ch9.Shared/App.xaml.cs
+++ b/src/Ch9/Ch9.Shared/App.xaml.cs
@@ -285,9 +285,17 @@ namespace Ch9
 				if ((_rootFrame.Content as FrameworkElement)?.DataContext is ShowPageViewModel showPage &&
 					showPage.Show.SelectedEpisode != null && showPage.IsNarrowAndSelected)
 				{
-					showPage.Show.DismissSelectedEpisode.Execute(null);
 					e.Handled = true;
-					//don't navigate back as NarrowAndSelected
+
+					//Dismiss episode only if we are not in full screen
+					if (!showPage.Show.IsVideoFullWindow)
+					{
+						showPage.Show.DismissSelectedEpisode.Execute(null);
+						//don't navigate back as NarrowAndSelected
+						return;
+					}
+
+					showPage.Show.IsVideoFullWindow = false;
 					return;
 				}
 
@@ -306,7 +314,15 @@ namespace Ch9
 				if ((_rootFrame.Content as FrameworkElement)?.DataContext is MainPageViewModel mainPage &&
 					mainPage.Show.SelectedEpisode != null)
 				{
-					mainPage.Show.DismissSelectedEpisode.Execute(null);
+					if (!mainPage.Show.IsVideoFullWindow)
+					{
+						mainPage.Show.DismissSelectedEpisode.Execute(null);
+					}
+					else
+					{
+						mainPage.Show.IsVideoFullWindow = false;
+					}
+
 					e.Handled = true;
 				}
 			}

--- a/src/Ch9/Ch9.Shared/MainPage.xaml
+++ b/src/Ch9/Ch9.Shared/MainPage.xaml
@@ -184,7 +184,7 @@
 											  win:BorderThickness="1"
 											  CornerRadius="9"
 											  Elevation="8"
-											  Margin="16,16,12,8">
+											  Margin="16,16,12,10">
 							<Grid Background="{StaticResource Color02Brush}">
 								<StackPanel>
 

--- a/src/Ch9/Ch9.Shared/Styles/Controls/MediaPlayerElement.xaml
+++ b/src/Ch9/Ch9.Shared/Styles/Controls/MediaPlayerElement.xaml
@@ -244,6 +244,7 @@
 			<Setter.Value>
 				<ControlTemplate TargetType="MediaTransportControls">
 					<Grid x:Name="RootGrid"
+					      toolkit:VisibleBoundsPadding.PaddingMask="All"
 						  Background="{TemplateBinding Background}">
 
 						<VisualStateManager.VisualStateGroups>
@@ -458,7 +459,6 @@
 						<Grid x:Name="FullScreenPanel"
 							  HorizontalAlignment="Right"
 							  VerticalAlignment="Bottom"
-							  toolkit:VisibleBoundsPadding.PaddingMask="All"
 							  Margin="0,8,8,32">
 
 							<!-- Full Window Button -->

--- a/src/Ch9/Ch9.Shared/ViewModels/MainPageViewModel.cs
+++ b/src/Ch9/Ch9.Shared/ViewModels/MainPageViewModel.cs
@@ -35,7 +35,7 @@ namespace Ch9
 
 		public ICommand DisplayShow { get; set; }
 
-		public TaskNotifier<IEnumerable<ShowItemViewModel>> _shows;
+		private TaskNotifier<IEnumerable<ShowItemViewModel>> _shows;
 		public TaskNotifier<IEnumerable<ShowItemViewModel>> Shows
 		{
 			get => _shows;

--- a/src/Ch9/Ch9.Shared/ViewModels/ShowViewModel.cs
+++ b/src/Ch9/Ch9.Shared/ViewModels/ShowViewModel.cs
@@ -69,23 +69,7 @@ namespace Ch9.ViewModels
         public EpisodeViewModel SelectedEpisode
         {
             get => _selectedEpisode;
-            set
-            {
-	            Set(() => SelectedEpisode, ref _selectedEpisode, value);
-#if __IOS__
-				var rootController = (UIKit.UINavigationController)UIKit.UIApplication.SharedApplication.KeyWindow.RootViewController;
-
-				if (SelectedEpisode == null)
-				{
-					//TODO investigate why This is not working 
-					rootController.InteractivePopGestureRecognizer.Enabled = true;
-				}
-				else
-				{
-					rootController.InteractivePopGestureRecognizer.Enabled = false;
-				}
-#endif
-			}
+            set => Set(() => SelectedEpisode, ref _selectedEpisode, value);
         }
 
         private bool _isVideoFullWindow;

--- a/src/Ch9/Ch9.Shared/ViewModels/ShowViewModel.cs
+++ b/src/Ch9/Ch9.Shared/ViewModels/ShowViewModel.cs
@@ -69,7 +69,23 @@ namespace Ch9.ViewModels
         public EpisodeViewModel SelectedEpisode
         {
             get => _selectedEpisode;
-            set => Set(() => SelectedEpisode, ref _selectedEpisode, value);
+            set
+            {
+	            Set(() => SelectedEpisode, ref _selectedEpisode, value);
+#if __IOS__
+				var rootController = (UIKit.UINavigationController)UIKit.UIApplication.SharedApplication.KeyWindow.RootViewController;
+
+				if (SelectedEpisode == null)
+				{
+					//TODO investigate why This is not working 
+					rootController.InteractivePopGestureRecognizer.Enabled = true;
+				}
+				else
+				{
+					rootController.InteractivePopGestureRecognizer.Enabled = false;
+				}
+#endif
+			}
         }
 
         private bool _isVideoFullWindow;


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix


## What is the current behavior?

- On iphoneX, expand button when playing video in full screen is under the video time bar 
- On android, if using the hardware back button in full screen video, the app is stuck in landscape

## What is the new behavior?

- IphoneX expand button is now right aligned
- Android hardware back button now dismiss the episode like when clicking on the expand button


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
