### PR TITLE
chore: added ref to latest uno.ui for all heads

### DIFF
--- a/src/Ch9/Ch9.Droid/Ch9.Droid.csproj
+++ b/src/Ch9/Ch9.Droid/Ch9.Droid.csproj
@@ -65,6 +65,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Uno.Material" Version="1.0.0-dev.481" />
+    <PackageReference Include="Uno.UI">
+      <Version>3.0.0-dev.1549</Version>
+    </PackageReference>
     <PackageReference Include="Uno.UI.Lottie" Version="3.0.0-dev.1493" />
     <PackageReference Include="Com.Airbnb.Android.Lottie" Version="3.4.2" />
     <PackageReference Include="Uno.UniversalImageLoader" Version="1.9.32" />
@@ -82,7 +85,7 @@
     <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.1.0" />
     <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0" />
     <PackageReference Include="Xamarin.AndroidX.RecyclerView" Version="1.1.0" />
-		<PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainActivity.cs" />

--- a/src/Ch9/Ch9.UWP/Ch9.UWP.csproj
+++ b/src/Ch9/Ch9.UWP/Ch9.UWP.csproj
@@ -120,13 +120,16 @@
     <PackageReference Include="System.ServiceModel.Syndication" Version="4.7.0" />
     <PackageReference Include="Uno.Material" Version="1.0.0-dev.481" />
     <PackageReference Include="MvvmLight" Version="5.4.1.1" />
+    <PackageReference Include="Uno.UI">
+      <Version>3.0.0-dev.1549</Version>
+    </PackageReference>
     <PackageReference Include="WindowsStateTriggers" Version="1.1.0" />
     <PackageReference Include="Microsoft.Toolkit.Uwp.UI" Version="6.0.0" />
     <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Controls" Version="6.0.0" />
     <PackageReference Include="Xamarin.Essentials" Version="1.2.0" />
     <PackageReference Include="Microsoft.AppCenter.Analytics" Version="3.2.2" />
     <PackageReference Include="Microsoft.AppCenter.Crashes" Version="3.2.2" />
-		<PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Assets\LargeTile.scale-100.png" />

--- a/src/Ch9/Ch9.Wasm/Ch9.Wasm.csproj
+++ b/src/Ch9/Ch9.Wasm/Ch9.Wasm.csproj
@@ -65,7 +65,7 @@
 		<PackageReference Include="System.ServiceModel.Syndication" Version="4.7.0" />
 		<PackageReference Include="Uno.GalaSoft.MvvmLight.Platform" Version="5.4.0-uno.134" />
     <PackageReference Include="Uno.Material" Version="1.0.0-dev.481" />
-    <PackageReference Include="Uno.UI" Version="3.0.0-dev.1512" />
+    <PackageReference Include="Uno.UI" Version="3.0.0-dev.1549" />
     <PackageReference Include="Uno.UI.Lottie" Version="3.0.0-dev.1493" />
 		<PackageReference Include="Uno.UI.WebAssembly" Version="3.0.0-dev.1493" />
 		<PackageReference Include="Uno.UI.RemoteControl" Version="3.0.0-dev.1493" Condition="'$(Configuration)'=='Debug'" />

--- a/src/Ch9/Ch9.iOS/Ch9.iOS.csproj
+++ b/src/Ch9/Ch9.iOS/Ch9.iOS.csproj
@@ -122,6 +122,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Uno.Material" Version="1.0.0-dev.481" />
+    <PackageReference Include="Uno.UI">
+      <Version>3.0.0-dev.1549</Version>
+    </PackageReference>
     <PackageReference Include="Uno.UI.Lottie" Version="3.0.0-dev.1493" />
     <PackageReference Include="Com.Airbnb.iOS.Lottie" Version="2.5.11" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
@@ -133,7 +136,7 @@
     <PackageReference Include="Xamarin.Essentials" Version="1.5.3.2" />
     <PackageReference Include="Microsoft.AppCenter.Analytics" Version="3.2.2" />
     <PackageReference Include="Microsoft.AppCenter.Crashes" Version="3.2.2" />
-		<PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
   </ItemGroup>
   <ItemGroup>
     <ImageAsset Include="Media.xcassets\AppIcons.appiconset\Contents.json">

--- a/src/Ch9/Ch9.macOS/Ch9.macOS.csproj
+++ b/src/Ch9/Ch9.macOS/Ch9.macOS.csproj
@@ -71,6 +71,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Uno.Material" Version="1.0.0-dev.481" />
+    <PackageReference Include="Uno.UI">
+      <Version>3.0.0-dev.1549</Version>
+    </PackageReference>
     <PackageReference Include="Uno.UI.Lottie" Version="3.0.0-dev.1493" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
@@ -78,7 +81,7 @@
     <PackageReference Include="Uno.GalaSoft.MvvmLight.Platform" Version="5.4.0-uno.134" />
     <PackageReference Include="Uno.WindowsStateTriggers" Version="1.1.1-uno.132" />
     <PackageReference Include="Uno.Microsoft.Toolkit.Uwp.UI.Controls" Version="6.1.0-build.186.g928c99f74d" />
-		<PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
   </ItemGroup>
   <ItemGroup>
     <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Contents.json" />


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Added reference to `Uno.UI` for all heads to have latest fixes 

## What is the current behavior?

- `Uno.UI `reference only for wasm, other heads rely on the `Uno.UI` version of `Uno.Material.` 


## What is the new behavior?

- This update brings a fix for the navigate back icon of the navigation view that was disappearing when tapping outside the navigation pane when the navigation stack contains more than one item on `iOS `& `Android`


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
