### PR TITLE
Resolve error when visualizing recent shows 

### DIFF
--- a/src/Ch9/Ch9.Droid/Ch9.Droid.csproj
+++ b/src/Ch9/Ch9.Droid/Ch9.Droid.csproj
@@ -17,7 +17,7 @@
     <AndroidUseAapt2>true</AndroidUseAapt2>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <AndroidUseLatestPlatformSdk>False</AndroidUseLatestPlatformSdk>
-    <TargetFrameworkVersion>v10.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v11.0</TargetFrameworkVersion>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <AndroidUseIntermediateDesignerFile>True</AndroidUseIntermediateDesignerFile>
     <ResourcesDirectory>..\Ch9.Shared\Strings</ResourcesDirectory>

--- a/src/Ch9/Ch9.Shared/Domain/ShowService.cs
+++ b/src/Ch9/Ch9.Shared/Domain/ShowService.cs
@@ -150,22 +150,30 @@ namespace Ch9
             DateTimeOffset? startTime = null;
             DateTimeOffset? endTime = null;
             Boolean? isLive = null;
-            bool inArray = false; // The url returns an Object with a property named "content" which is an Array
+            bool? inArray = null;
+
+            // The url returns an Object with a property named "content" which is an Array
             while (await reader.ReadAsync())
             {
-                if (!inArray)
+                if (inArray == null)
                 {
+                    if (reader.TokenType == JsonToken.StartArray)
+                    {
+                        inArray = true;
+                    }
+
                     continue;
+                } else if (inArray == false) {
+                    continue;
+                } else if (inArray == true) {
+                    if (reader.TokenType == JsonToken.EndArray) {
+                        inArray = false;
+                        continue;
+                    }
                 }
 
                 switch (reader.TokenType)
                 {
-                    case JsonToken.StartArray:
-                        inArray = true;
-                        break;
-                    case JsonToken.EndArray:
-                        inArray = false;
-                        break;
                     case JsonToken.StartObject:
                         currentItem = new SyndicationItem();
                         break;
@@ -230,7 +238,13 @@ namespace Ch9
                                 break;
                         }
                         break;
-                    // Commented out because not necessary, but useful for future improvements
+                    // Commented out because not necessary, but can be useful for future improvements
+                    //case JsonToken.StartArray:
+                    //    inArray = true;
+                    //    break;
+                    //case JsonToken.EndArray:
+                    //    inArray = false;
+                    //    break;
                     //case JsonToken.Undefined:
                     //	break;
                     //case JsonToken.None:

--- a/src/Ch9/Ch9.Shared/Framework/HttpUtility.cs
+++ b/src/Ch9/Ch9.Shared/Framework/HttpUtility.cs
@@ -2,36 +2,50 @@
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Xml;
+using Newtonsoft.Json;
 
 namespace Ch9
 {
     internal static class HttpUtility
     {
-	    internal static HttpClient HttpClient { get; } = CreateHttpClient();
+        internal static HttpClient HttpClient { get; } = CreateHttpClient();
 
         internal static HttpClient CreateHttpClient()
         {
 #if __WASM__
             var httpClient = new HttpClient(new Uno.UI.Wasm.WasmHttpHandler());
 
-			httpClient.DefaultRequestHeaders.Add("origin", "");
+            httpClient.DefaultRequestHeaders.Add("origin", "");
 #else
-			var httpClient = new HttpClient();
+            var httpClient = new HttpClient();
 #endif
-	        return httpClient;
-		}
+            return httpClient;
+        }
 
-		internal static async Task<XmlReader> GetXmlReader(string url)
+        internal static async Task<XmlReader> GetXmlReader(string url)
         {
 #if __WASM__
-			url = "https://ch9-app.azurewebsites.net/api/proxy?url=" + url;
+            url = "https://ch9-app.azurewebsites.net/api/proxy?url=" + url;
 #endif
-			using (var response = await HttpClient.GetAsync(url))
+            using (var response = await HttpClient.GetAsync(url))
             {
                 response.EnsureSuccessStatusCode();
                 var bytes = await response.Content.ReadAsByteArrayAsync();
                 var stream = new MemoryStream(bytes);
                 return XmlReader.Create(stream);
+            }
+        }
+
+        internal static async Task<JsonTextReader> GetJsonReader(string url)
+        {
+            using (var response = await HttpClient.GetAsync(url))
+            {
+                response.EnsureSuccessStatusCode();
+                var bytes = await response.Content.ReadAsByteArrayAsync();
+                var stream = new MemoryStream(bytes);
+                TextReader reader = new StreamReader(stream);
+                JsonTextReader jsonReader = new JsonTextReader(reader);
+                return jsonReader;
             }
         }
     }

--- a/src/Ch9/Ch9.UWP/Ch9.UWP.csproj
+++ b/src/Ch9/Ch9.UWP/Ch9.UWP.csproj
@@ -145,7 +145,7 @@
     <PackageReference Include="WindowsStateTriggers" Version="1.1.0" />
     <PackageReference Include="Microsoft.Toolkit.Uwp.UI" Version="6.0.0" />
     <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Controls" Version="6.0.0" />
-    <PackageReference Include="Xamarin.Essentials" Version="1.2.0" />
+    <PackageReference Include="Xamarin.Essentials" Version="1.5.3.2" />
     <PackageReference Include="Microsoft.AppCenter.Analytics" Version="3.2.2" />
     <PackageReference Include="Microsoft.AppCenter.Crashes" Version="3.2.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />

--- a/src/Ch9/Ch9.UWP/Ch9.UWP.csproj
+++ b/src/Ch9/Ch9.UWP/Ch9.UWP.csproj
@@ -132,7 +132,7 @@
 			you need to make sure that the version provided here matches https://github.com/onovotny/MSBuildSdkExtras/blob/master/Source/MSBuild.Sdk.Extras/DefaultItems/ImplicitPackages.targets#L11.
 			This is not an issue when libraries are referenced through nuget packages. See https://github.com/unoplatform/uno/issues/446 for more details.
 			-->
-      <Version>6.2.8</Version>
+      <Version>6.2.9</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.2" />


### PR DESCRIPTION
# Change the source of the 

Now that Channel 9 is merged with Microsoft Learn TV, the "Recent" tab shows an error.
I didn't find as RSS feed for the new site, so I resolved to use the endpoint to obtain the JSON file of the schedule, to parse it and to adapt the parsed results to the existing behaviour.
Tested only the UWP project.

## PR Type

I've made these types of changes:

- Bugfix
- Feature
- Build or CI related changes

## What is the current behavior?

Get an RSS feed from the Channel 9 site.
Tested only the UWP project.

## What is the new behavior?

Gets a JSON file with the scheduled shows from the Microsoft Learn TV site.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x ] Tested code with current UWP
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)


## Other information